### PR TITLE
#791 The in-memory hash masked low bits that carried no entropy

### DIFF
--- a/src/Typhon.Engine/Foundation/Collections/internals/HashUtils.cs
+++ b/src/Typhon.Engine/Foundation/Collections/internals/HashUtils.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace Typhon.Engine.Internals;
@@ -14,9 +16,12 @@ internal static unsafe class HashUtils
 
     /// <summary>
     /// Compute the hash of a key. JIT eliminates dead branches based on <c>sizeof(TKey)</c>:
-    /// 4 bytes → Fibonacci multiply, 8 bytes → XOR-fold + Fibonacci, 16 bytes → XOR-fold-4 + Fibonacci,
-    /// other → xxHash32 (generic bytes).
+    /// 4, 8 and 16 bytes each take a widening Fibonacci multiply followed by a fold and two avalanche shifts; other sizes take xxHash32 over the bytes.
     /// </summary>
+    /// <remarks>
+    /// Every consumer of this method masks the LOW bits of the result to pick a bucket. <see cref="FastHash64"/> documents what that requires of the hash and
+    /// what happens when it is not met (#791) — read it before changing any of these.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static uint ComputeHash<TKey>(TKey key) where TKey : unmanaged
     {
@@ -50,42 +55,126 @@ internal static unsafe class HashUtils
         return h;
     }
 
+    /// <summary>Multiplier for the widening Fibonacci step — the 64-bit golden-ratio constant (odd, so the multiply is a bijection).</summary>
+    private const ulong Fibonacci64 = 0x9E3779B97F4A7C15UL;
+
+    /// <summary>Second and third multipliers of the splitmix64 finalizer. Odd, so each step stays a bijection.</summary>
+    private const ulong Mix64A = 0xBF58476D1CE4E5B9UL;
+    private const ulong Mix64B = 0x94D049BB133111EBUL;
+
     /// <summary>
-    /// Fast 2-operation hash for 4-byte keys: Fibonacci multiplicative hash + mix.
-    /// ~2 cycles — 3x faster than WangJenkins, good distribution for open addressing.
+    /// The splitmix64 finalizer, truncated to 32 bits. Every output bit depends on every input bit — which is what the consumers need and what a
+    /// shift-pair-and-fold does not give.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This replaced a hand-tuned <c>(hi^lo)</c> fold plus two shifts, because that shape had a provable blind spot.</b> With <c>h_i = z_i ^ z_{i+32}</c>
+    /// and shifts of 15 and 7, output bit 0 is <c>h_0 ^ h_7 ^ h_15 ^ h_22</c>, which reaches input bit 54 and no further — so bits 55-63 could not influence
+    /// the lowest bucket bit at all, and any key family constant below bit 55 landed only on EVEN buckets. Measured on <c>(i&lt;&lt;55) | 0x0123456789AB</c>:
+    /// 9.69 mean / 72 max probes at 75 % load, against a documented claim of "no family exceeds ~2.1 mean or ~53 max". Not reachable from <c>EntityId</c>
+    /// (bits 55-63 need 2^39 entities), but this is a shared utility and the next 8-byte key is not <c>EntityId</c>.
+    /// </para>
+    /// <para>
+    /// Reasoning about which shift pair avalanches which bit is how that blind spot survived a 17-family measured sweep. splitmix64's finalizer is published,
+    /// widely analysed, and passes the standard avalanche criterion; the two extra multiplies cost ~2 ns against re-deriving the argument on every edit.
+    /// </para>
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    internal static uint FastHash32(uint h)
+    private static uint Finalize64(ulong z)
     {
-        h *= 0x9E3779B9u; // Fibonacci / golden ratio — 1 multiply, ~1 cycle
+        z ^= z >> 30;
+        z *= Mix64A;
+        z ^= z >> 27;
+        z *= Mix64B;
+        z ^= z >> 31;
+        return (uint)z;
+    }
+
+    /// <summary>
+    /// Hash for 4-byte keys: widening Fibonacci multiply then the shared finalizer. <b>~3.3 ns</b> dependency-chain latency (Zen 4, .NET 10, measured).
+    /// </summary>
+    /// <remarks>
+    /// Shares its shape — and its rationale — with <see cref="FastHash64"/>; see that method for why the fold and the two shifts are not optional.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    internal static uint FastHash32(uint key)
+    {
+        uint h = Finalize64(key * Fibonacci64);
         return h == 0 ? 1u : h; // sentinel: 0 means empty slot in open addressing
     }
 
     /// <summary>
-    /// Fast hash for 8-byte keys: XOR-fold to 32 bits, then single Fibonacci multiply.
-    /// ~2 cycles. Optimal distribution for sequential keys with power-of-2 masking:
-    /// consecutive golden-ratio multiples are maximally spaced (avg probe 1.0 at 75% load).
+    /// Hash for 8-byte keys: widening Fibonacci multiply then the shared finalizer. <b>~3.3 ns</b> dependency-chain latency (Zen 4, .NET 10, measured — the
+    /// figure previously stated here was ~0.7 ns, which was 4.7x optimistic and is the number capacity planning would have used).
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Every step here exists because its absence was measured (#791).</b> The consumers — <c>HashMap</c>, <c>HashMapKV</c>, <c>ConcurrentHashMap</c>,
+    /// <c>ConcurrentHashMapKV</c> — take the bucket index as <c>hash &amp; (capacity-1)</c>, the LOW bits. That single fact constrains the whole function.
+    /// </para>
+    /// <para>
+    /// <b>Why the multiply is widening and the high half is folded down.</b> Multiplication propagates entropy upward only: <c>(h·K) mod 2^b</c> is a
+    /// bijection of <c>h mod 2^b</c> alone. A 32-bit Fibonacci multiply whose product is then masked at the low end is therefore a permutation of the low bits
+    /// and nothing more — for any key family with constant low bits it maps every key to one bucket. That is what this function used to do, and
+    /// <c>EntityId</c> is <c>(entityKey &lt;&lt; 16) | archetypeId</c>, so all 50 000 entities of one archetype landed in 2 buckets of 131 072 and every set
+    /// operation walked a 25 000-long probe chain. Multiplying into 64 bits and folding the high half down moves that upward-propagated entropy into the range
+    /// the consumer actually reads.
+    /// </para>
+    /// <para>
+    /// <b>Why the key is not XOR-folded to 32 bits first.</b> The previous shape did, and folding before mixing destroys information that no later step can
+    /// recover: <c>(i &lt;&lt; 32) | i</c> folds to zero for every <c>i</c>. Measured, that family is pathological under the old hash and stays pathological
+    /// under it plus any amount of post-mixing.
+    /// </para>
+    /// <para>
+    /// <b>Why the mixing is splitmix64 and not a hand-tuned shift pair.</b> It was a shift pair — <c>(hi^lo)</c> then <c>^15</c> and <c>^7</c> — chosen by
+    /// sweeping a 17-family matrix. That shape had a blind spot the sweep could not see, because no family in it isolated the top of the key: output bit 0
+    /// could not depend on input bits 55-63 at all. <see cref="Finalize64"/> carries the proof and the measurement. The lesson is the general one — a mixer
+    /// justified by "these families measured well" is only as good as the families someone thought to write, while a published finalizer is justified by an
+    /// avalanche argument that holds for families nobody enumerated.
+    /// </para>
+    /// <para>
+    /// <b>The trade this makes.</b> Purely sequential keys used to average 1.00 probes — a low-bit mask of a Fibonacci product is a bijection for them, which
+    /// is the best case that can exist. They now average ~1.3, and the mixing costs two extra multiplies (~2 ns). In exchange the distribution guarantee no
+    /// longer rests on which key families happened to be measured. A ceiling that holds for families nobody enumerated is worth more than an optimum on one,
+    /// because the family that pays for that optimum is the one the engine actually stores.
+    /// </para>
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     internal static uint FastHash64(ulong key)
     {
-        uint h = (uint)key ^ (uint)(key >> 32);
-        h *= 0x9E3779B9u; // Fibonacci / golden ratio
+        uint h = Finalize64(key * Fibonacci64);
         return h == 0 ? 1u : h;
     }
 
     /// <summary>
-    /// Fast hash for 16-byte keys (Guid): XOR-fold 4 uints, then Fibonacci multiply with extra mixing.
-    /// ~4 cycles — 5x faster than xxHash32_Bytes for 16 bytes, good distribution for open addressing.
+    /// Fast hash for 16-byte keys (Guid): combine both halves through the widening Fibonacci step, then avalanche.
+    /// <b>~4.5 ns</b> dependency-chain latency (Zen 4, .NET 10, measured) — still well under xxHash32_Bytes over 16 bytes, and it spreads every Guid-shaped
+    /// family tested at 2.46-2.56 mean probes at 75 % load, i.e. on Knuth's theoretical optimum for linear probing.
     /// </summary>
+    /// <remarks>
+    /// Ends in shifts rather than in a multiply for the reason spelled out on <see cref="FastHash64"/>: the consumers mask the LOW bits, and a bare trailing
+    /// multiply leaves those bits a function of the low bits of its input alone (#791). The two 64-bit halves are combined multiplicatively rather than
+    /// XOR-folded so that a key whose halves cancel does not collapse to a constant.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     internal static uint FastHash128(byte* key)
     {
-        uint* p = (uint*)key;
-        uint h = p[0] ^ p[1] ^ p[2] ^ p[3];
-        h *= 0x85EBCA6Bu;
-        h ^= h >> 16;
-        h *= 0x9E3779B9u;
+        ulong* p = (ulong*)key;
+
+        // The two halves are combined by a FOLDED WIDENING MULTIPLY, not by XOR, and that choice is the whole point of this line.
+        //
+        // Two shapes have been tried and measured here. The first was `p0*K ^ rotl(p1*K, 32)`: a rotate of 32 is an involution on the halves, so for p0 == p1
+        // the fold gave hi(z) == lo(z), collapsed to 0, and EVERY 16-byte key with two equal halves — (id,id), (from,to) with from==to — landed on bucket 1.
+        // Measured: 65 536 such keys → 1 distinct home bucket, mean 32 768 probes. The second used distinct multipliers and an odd rotate, which fixes every
+        // NATURAL family (seven Guid shapes measured at 2.46-2.56 mean probes at 75 % load) but leaves the combine SEPARABLE: `f(p0) ^ g(p1)` with both
+        // bijections means that for any p0 there is exactly one p1 giving a chosen hash. Measured: 32 768 constructed keys → 1 distinct hash.
+        //
+        // A widening multiply of the two halves is not separable — neither operand can be solved against the other to hit a target, because the fold mixes
+        // the 128-bit product's halves together. The XOR of a constant into each operand keeps a zero half from annihilating the product. Same probe counts
+        // as the XOR version on every natural family, ~1 ns more, and the entire "solve one half against the other" class disappears rather than becoming
+        // harder to reach. Reachability was never the argument for keeping it — the cost of removing the class was one line.
+        ulong high = Math.BigMul(p[0] ^ Fibonacci64, p[1] ^ Mix64A, out ulong low);
+        uint h = Finalize64(high ^ low);
         return h == 0 ? 1u : h;
     }
 

--- a/test/Typhon.Engine.Tests/Collections/HashDistributionTests.cs
+++ b/test/Typhon.Engine.Tests/Collections/HashDistributionTests.cs
@@ -1,0 +1,266 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Typhon.Engine.Internals;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// Issue #791 — <see cref="HashUtils"/> feeds open-addressed maps that mask the LOW bits of the hash to pick a bucket, so the hash must spread key families
+/// whose low bits carry no entropy. It did not: a Fibonacci multiply masked at the low end is a permutation of the low bits alone, and
+/// <c>EntityId = (entityKey &lt;&lt; 16) | archetypeId</c> holds a constant there.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>These tests assert probe length, not correctness.</b> The broken hash was correct — every lookup returned the right answer, at 25 000 probes each. The
+/// pre-existing fixtures use <c>i</c> and <c>i * 7 + 1</c>, whose entropy is entirely in the low bits, which is precisely the family a low-bit mask of a
+/// Fibonacci product handles perfectly. A distribution defect is only visible to a test that measures distribution.
+/// </para>
+/// <para>
+/// The bound is deliberately loose (<see cref="MaxMeanProbes"/>). It is not tuned to the current function — it sits where "the map still behaves like a
+/// hash map" stops being true, so a future hash change may move the numbers around inside it and is caught the moment it reintroduces a chain.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class HashDistributionTests
+{
+    /// <summary>Linear probing at 75 % load averages ~1.8 probes for a uniform hash; 4 is well past any healthy function and far below a collapse.</summary>
+    private const double MaxMeanProbes = 4.0;
+
+    /// <summary>A single lookup should never walk a chain. 256 is ~5x the worst family measured and ~100x below a collapsed bucket.</summary>
+    private const int MaxWorstProbes = 256;
+
+    private const int KeyCount = 20_000;
+
+    private static IEnumerable<TestCaseData> KeyFamilies()
+    {
+        // The family that broke: 48-bit monotonic key in the high bits, constant 16-bit archetype routing id in the low bits.
+        yield return Family("EntityId, one archetype", i => ((long)i << 16) | 1);
+
+        // A polymorphic view spans several archetypes — a few distinct low-bit values rather than one.
+        yield return Family("EntityId, eight archetypes", i => ((long)i << 16) | (uint)(i % 8));
+
+        // A churned archetype: the key space is sparse because destroyed keys are never recycled.
+        yield return Family("EntityId, sparse keys", i => ((long)i * 977 << 16) | 3);
+
+        // Aligned offsets — low bits structurally zero.
+        yield return Family("64-byte aligned", i => (long)i * 64);
+        yield return Family("4096-byte aligned", i => (long)i * 4096);
+
+        // Two small fields packed into one key: both halves have low entropy, and an XOR-fold would collide them wholesale.
+        yield return Family("packed pair", i => ((long)(i % 1024) << 32) | (uint)(i / 1024));
+
+        // The XOR-fold trap: folding the two halves together yields zero for every key.
+        yield return Family("halves cancel under XOR-fold", i => ((long)i << 32) | (uint)i);
+
+        // Entropy only in the high half — the mirror image of the family that broke.
+        yield return Family("high half only", i => (long)i << 32);
+
+        // Entropy only in the TOP of the key. The previous mixer folded (hi^lo) then shifted by 15 and 7, which left output bit 0 a function of input bits
+        // 0-54 alone — so a family whose entropy sits above bit 54 landed exclusively on even buckets and measured 9.69 mean / 72 max at 75 % load, while
+        // every family anyone had thought to write passed. 20 000 keys need 15 bits, so bit 48 is the highest base that keeps them distinct (48+15 = 63);
+        // eight of those fifteen bits sit above 54, which is enough to expose the blind spot. It is here because no sweep finds a hole it has no probe for.
+        yield return Family("entropy above bit 48", i => (long)i << 48);
+
+        // Families the OLD hash handled perfectly. They must not regress into a chain.
+        yield return Family("sequential", i => i);
+        yield return Family("sequential, large offset", i => 1_000_000_000L + i);
+    }
+
+    /// <summary>
+    /// 16-byte keys, which <see cref="HashUtils.ComputeHash{TKey}"/> routes to <c>FastHash128</c>. Structurally separate from the 8-byte matrix because the
+    /// defect this guards is about how the two halves COMBINE, which no single-word family can express.
+    /// </summary>
+    private static IEnumerable<TestCaseData> Guid16Families()
+    {
+        // The collapse: with one shared multiplier and a rotate of 32, `z = y ^ rotl(y,32)` has hi(z) == lo(z) for equal halves, the (hi^lo) fold yields 0,
+        // and EVERY such key hashed to the sentinel 1. Real shapes that hit it: (id, id), (from, to) where from == to, a zeroed second field.
+        yield return Guid16("equal halves", i => ((ulong)i, (ulong)i));
+
+        // The same cancellation one step removed — halves that differ by a rotation rather than being identical.
+        yield return Guid16("halves are rotations", i => ((ulong)i, BitOperations.RotateLeft((ulong)i, 32)));
+
+        // One half constant: the shape of a composite key whose second field is rarely set.
+        yield return Guid16("high half zero", i => ((ulong)i, 0UL));
+        yield return Guid16("low half zero", i => (0UL, (ulong)i));
+
+        // Both halves low-entropy and correlated.
+        yield return Guid16("both halves small", i => ((ulong)(i % 512), (ulong)(i / 512)));
+
+        // The healthy baseline — must not regress.
+        yield return Guid16("independent halves", i => ((ulong)i * 0x9E3779B97F4A7C15UL, (ulong)i * 0xC2B2AE3D27D4EB4FUL));
+
+        // The CONSTRUCTIBLE lattice. An XOR-combine of two invertible functions, `f(p0) ^ g(p1)`, is SEPARABLE: for any p0 you can solve p1 so the two terms
+        // cancel exactly, and a whole family lands on one hash. This generator does that against the shape the function briefly had —
+        // `(p0*Fib) ^ rotl(p1*Mix64A, 29)` — by inverting it: `p1 = rotr(p0*Fib, 29) * Mix64A⁻¹`, where the inverse is mod 2^64 (Mix64A is odd, so it exists).
+        // Verified in Python: z == 0 for every constructed pair, hence one hash for the whole family.
+        //
+        // That shape spread every NATURAL family perfectly — seven Guid shapes at 2.46-2.56 mean probes — which is exactly why "no realistic key hits it" was
+        // an argument for shipping it, and exactly why that argument is worth a regression test rather than a comment. The widening-multiply combine is not
+        // separable, so this family spreads.
+        yield return Guid16("constructed to cancel a separable combine",
+            i => ((ulong)i, BitOperations.RotateRight((ulong)i * 0x9E3779B97F4A7C15UL, 29) * 0x96DE1B173F119089UL));
+    }
+
+    private static TestCaseData Guid16(string name, Func<int, (ulong Lo, ulong Hi)> gen)
+    {
+        var keys = new (ulong Lo, ulong Hi)[KeyCount];
+        for (var i = 0; i < KeyCount; i++)
+        {
+            keys[i] = gen(i + 1);
+        }
+        return new TestCaseData((object)keys).SetName($"SixteenByteKeysSpreadAcrossBuckets({name})");
+    }
+
+    /// <summary>Every 16-byte family must spread, for the same reason the 8-byte ones must — the consumers mask the LOW bits of the result.</summary>
+    [Test]
+    [TestCaseSource(nameof(Guid16Families))]
+    public void SixteenByteKeysSpreadAcrossBuckets((ulong Lo, ulong Hi)[] keys)
+    {
+        Assert.That(new HashSet<(ulong, ulong)>(keys).Count, Is.EqualTo(keys.Length), "PREMISE: the family generates distinct keys");
+
+        var capacity = 1;
+        while (capacity < (int)(keys.Length / 0.75))
+        {
+            capacity <<= 1;
+        }
+
+        var buckets = new HashSet<uint>();
+        var histogram = new int[capacity];
+        foreach (var key in keys)
+        {
+            var k = key;
+            var hash = HashUtils.ComputeHash(k);
+            var bucket = hash & (uint)(capacity - 1);
+            buckets.Add(bucket);
+            histogram[bucket]++;
+        }
+
+        var worst = 0;
+        foreach (var count in histogram)
+        {
+            if (count > worst)
+            {
+                worst = count;
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buckets.Count, Is.GreaterThan(keys.Length / 4),
+                $"{keys.Length} distinct 16-byte keys collapsed onto {buckets.Count} buckets of {capacity} — every one of them shares a probe chain");
+            Assert.That(worst, Is.LessThan(MaxWorstProbes),
+                $"the fullest bucket holds {worst} keys; a healthy hash at this load holds a handful");
+        });
+    }
+
+    private static TestCaseData Family(string name, Func<int, long> gen)
+    {
+        var keys = new long[KeyCount];
+        for (var i = 0; i < KeyCount; i++)
+        {
+            keys[i] = gen(i + 1);
+        }
+        return new TestCaseData(keys).SetName($"KeysSpreadAcrossBuckets({name})");
+    }
+
+    [Test]
+    [TestCaseSource(nameof(KeyFamilies))]
+    public void KeysSpreadAcrossBuckets(long[] keys)
+    {
+        // Distinct keys are a premise of the measurement, not a property under test: duplicates would share a bucket under ANY hash and would silently turn a
+        // distribution assertion into a tautology.
+        Assert.That(new HashSet<long>(keys).Count, Is.EqualTo(keys.Length), "PREMISE: the family generates distinct keys");
+
+        var (mean, worst, distinctBuckets) = MeasureProbes(keys);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mean, Is.LessThan(MaxMeanProbes),
+                $"mean probe length {mean:F2} — the map has degenerated into a linear scan. Every consumer that masks the low bits of the hash is affected.");
+            Assert.That(worst, Is.LessThan(MaxWorstProbes), $"worst-case probe length {worst}");
+            Assert.That(distinctBuckets, Is.GreaterThan(keys.Length / 4),
+                $"{distinctBuckets:N0} distinct home buckets for {keys.Length:N0} keys — the hash is mapping the family onto a handful of slots");
+        });
+    }
+
+    /// <summary>
+    /// Replays <c>HashMap</c>'s probe sequence — <c>hash &amp; (capacity-1)</c> then linear <c>+1</c> — over a table sized the way the map sizes itself.
+    /// </summary>
+    /// <remarks>
+    /// A replay rather than the real <c>HashMap</c> because the assertion is about probe COUNT, which the map does not expose; measuring wall-clock instead
+    /// would make the test a performance test, and those are not stable enough to gate a merge on.
+    /// </remarks>
+    private static (double Mean, int Worst, int DistinctBuckets) MeasureProbes(long[] keys)
+    {
+        var capacity = 4;
+        while (capacity < (int)(keys.Length / 0.75) + 1)
+        {
+            capacity <<= 1;
+        }
+
+        var mask = capacity - 1;
+        var occupied = new bool[capacity];
+        var homes = new HashSet<int>();
+        long total = 0;
+        var worst = 0;
+
+        foreach (var key in keys)
+        {
+            var hash = HashUtils.ComputeHash(key);
+            var idx = (int)(hash & (uint)mask);
+            homes.Add(idx);
+
+            var probes = 1;
+            while (occupied[idx])
+            {
+                idx = (idx + 1) & mask;
+                probes++;
+                if (probes > capacity)
+                {
+                    Assert.Fail("probe sequence wrapped the whole table — the hash maps this family onto a single bucket");
+                }
+            }
+
+            occupied[idx] = true;
+            total += probes;
+            worst = Math.Max(worst, probes);
+        }
+
+        return ((double)total / keys.Length, worst, homes.Count);
+    }
+
+    /// <summary>The 4-byte path shares the 8-byte path's shape and its failure mode; a constant low byte is the 32-bit analogue of the routing id.</summary>
+    [Test]
+    public void FourByteKeys_WithConstantLowBits_SpreadAcrossBuckets()
+    {
+        var keys = new long[KeyCount];
+        for (var i = 0; i < KeyCount; i++)
+        {
+            keys[i] = ((i + 1) << 8) | 0x3F;
+        }
+
+        var intKeys = new int[KeyCount];
+        for (var i = 0; i < KeyCount; i++)
+        {
+            intKeys[i] = (int)keys[i];
+        }
+
+        var capacity = 4;
+        while (capacity < (int)(KeyCount / 0.75) + 1)
+        {
+            capacity <<= 1;
+        }
+
+        var mask = capacity - 1;
+        var homes = new HashSet<int>();
+        foreach (var key in intKeys)
+        {
+            homes.Add((int)(HashUtils.ComputeHash(key) & (uint)mask));
+        }
+
+        Assert.That(homes.Count, Is.GreaterThan(KeyCount / 4),
+            $"{homes.Count:N0} distinct home buckets for {KeyCount:N0} 4-byte keys with constant low bits");
+    }
+}


### PR DESCRIPTION
Closes #791.

Split out of `feature/feat-790`, which also carries #722 and #790. This branch is **only** the hash: two files, no dependency on the other work, buildable and green on `main` alone.

## The defect

Every consumer of `HashUtils.ComputeHash` picks its bucket with `hash & (capacity-1)` — the **low** bits. The 8-byte function was a 32-bit Fibonacci multiply, and a Fibonacci product masked at the low end is a permutation of the low bits and nothing else, because multiplication propagates entropy *upward* only.

`EntityId` is `(entityKey << 16) | archetypeId`, so the low 16 bits are constant across an archetype. All 50 000 entities of one archetype landed in **2 buckets of 131 072**, and every set operation walked a ~25 000-long probe chain. That is what #790 reported from the field as a per-tick cost.

## The fix

All three fixed-size functions: widening multiply into 64 bits, then the **splitmix64 finalizer**.

The first attempt was a hand-tuned `(hi^lo)` fold plus shifts of 15 and 7, picked by sweeping a 17-family matrix. It had a blind spot the sweep could not contain a probe for — no family in it isolated the top of the key, and output bit 0 could not depend on input bits 55-63 **at all**. A family with entropy only up there measured 9.69 mean / 72 max probes while every family anyone had thought to write passed.

> A mixer justified by "these families measured well" is only as good as the families someone thought to write. A published finalizer is justified by an avalanche argument that holds for families nobody enumerated.

**The leading Fibonacci multiply is load-bearing, not decorative.** splitmix64 opens with `z ^= z >> 30`, a no-op for any key below 2³⁰ — that is every `EntityId` with `entityKey < 16 384`, i.e. the whole realistic range of the dominant key family. Measured: first stage dead for 16 383 keys, ≤2 bits of entropy for **all** 100 000 tested; after the multiply, dead for none.

**16-byte keys** combine their halves with a folded widening multiply. The previous shape used one shared multiplier and a rotate of 32 — and a rotate of 32 is an involution on the halves, so for equal halves the fold cancelled exactly and every such key (`(id,id)`, `(from,to)` with `from == to`) hashed to the sentinel: **65 536 keys onto 1 bucket, mean 32 768 probes**. Distinct multipliers and an odd rotate fix every natural family but leave the combine *separable* — one half can still be solved against the other to put a whole family on one hash. A widening multiply is not separable, so the class is removed rather than made harder to reach.

## Measurements

| | |
|---|---|
| Distribution | **2.46–2.56 mean probes at 75 % load** across 12 key families, against Knuth's 2.50 expected for linear probing |
| Regression | Sequential keys give up their former 1.00 — the best case that can exist, paid for by the family the engine actually stores |
| Cost | **~3.3 ns**/call. The figure previously documented was 0.7 ns — wrong by 4.7×, and the number capacity planning would have used. Corrected. |

Independently surveyed against fmix64, wyhash, rrmxmx, xxh3's avalanche step, rapidhash, komihash, XXH3 and others: every full-avalanche candidate measures *identically*, so there is no quality left to buy — only ~0.6 ns, which does not justify re-opening this function.

Taking the **high** bits instead (classic Fibonacci hashing) was evaluated and **rejected on measurement**: 7.36 mean probes vs 2.50 on the dominant key shape, from primary clustering rather than collisions, plus the exact mirror of this bug (keys varying only in high bits collapse to 1 bucket / 256 mean probes). Once a hash avalanches, which end you take is irrelevant — 2.49–2.51 either way. Bit position was the symptom; entropy distribution was the disease.

## Tests

`HashDistributionTests` — 18 families (10 × 8-byte, 6 × 16-byte, 1 × 4-byte, plus one constructed against the separable combine).

Every guard is ablation-proven, and one wasn't on the first try: the constructed-lattice family initially used an invented modular inverse and passed against the broken function. With the real inverse (`Mix64A⁻¹ mod 2⁶⁴`), reverting the combine gives `20000 distinct 16-byte keys collapsed onto 1 buckets of 32768`.

- 7 of the 10 8-byte families breach the thresholds under the **previous** function
- reverting the 128-bit fix turns `equal halves` red
- reverting to the separable combine turns `constructed to cancel a separable combine` red

## Not a format change

`PagedHashMap` and `RawValuePagedHashMap` — including `EntityMap`, whose bucket placement lives on disk — carry their **own private** hash functions and are untouched by this diff. Verified by two independent reviewers.

## Gate

All 6 policy jobs pass; Workbench 605/605; engine suite 5286/1 in Release, the one failure being a `TickFenceSingleVersion_…_Crash` parameterisation from the #720 flake band — 9/9 green in isolation ×3, a different parameterisation each run, and on a branch containing only hash changes it cannot be related to crash recovery.
