### PR TITLE
#404 Shutdown() promised a stable tick number while returning into the tick that increments it

### DIFF
--- a/src/Typhon.Engine/Runtime/public/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/public/DagScheduler.cs
@@ -702,8 +702,17 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     /// forever. A caller that needs the in-flight tick's work to land must stop dispatching and let the tick complete BEFORE calling this.
     /// </para>
     /// <para>
-    /// Does NOT stop the timer thread — <see cref="Dispose(bool)"/> does, via the base class. The thread stays alive but stops producing ticks, so
-    /// <see cref="CurrentTickNumber"/> is stable once this returns.
+    /// Does NOT stop the timer thread — <see cref="Dispose(bool)"/> does, via the base class, and that is the only quiescence point. The thread stays alive
+    /// here but stops producing ticks: <see cref="GetNextTick"/> returns <c>long.MaxValue</c> and <see cref="ExecuteCallbacks"/> bails out, both gated at
+    /// tick ENTRY. A tick already past that gate therefore runs to completion, and the increment of <see cref="CurrentTickNumber"/> is the last statement of
+    /// that tick's telemetry finalizer — so the counter can advance by ONE after this method returns. Never by more: <c>_workerShutdown</c> is published
+    /// before the join, so every later tick early-returns at the gate. Callers that need "nothing is running" must use <see cref="Dispose(bool)"/>.
+    /// </para>
+    /// <para>
+    /// May legitimately be called ON the timer thread. <see cref="TyphonRuntime.OnTickAborted"/> fires inside the tick-end callback and its documented
+    /// response is <see cref="TyphonRuntime.FatalStop"/>, which lands here — so on that path this returns INTO the tick it just stopped, and the one-tick
+    /// advance above is guaranteed rather than merely possible. Do not "fix" that by joining the timer thread here: it would be a self-join, which
+    /// <c>StopTimerThread</c>'s 2 s bound turns into a stall that returns <c>false</c> and changes nothing. See issue #404.
     /// </para>
     /// </summary>
     public void Shutdown()

--- a/src/Typhon.Engine/Runtime/public/TyphonRuntime.cs
+++ b/src/Typhon.Engine/Runtime/public/TyphonRuntime.cs
@@ -177,6 +177,11 @@ public sealed partial class TyphonRuntime : IDisposable
     /// Fires once when a tick is aborted under <see cref="SystemExceptionPolicy.AbortTickAndStop"/>, on the tick thread, after the tick has fully drained.
     /// Never fires for a successful tick, and never fires twice — the runtime is terminal after an abort. The handler should stop the runtime
     /// (<see cref="FatalStop"/>) and let the host decide whether to exit or rebuild the engine.
+    /// <para>
+    /// "Drained" means every system has run or been skipped — it does NOT mean the tick is over. The handler runs INSIDE the tick, on the tick thread, and
+    /// the tick's own end-of-tick accounting still runs after the handler returns. So <see cref="FatalStop"/> called from here takes effect after the current
+    /// tick completes, and <see cref="CurrentTickNumber"/> advances once more once it does. Do not block in this handler: you are holding up the tick thread.
+    /// </para>
     /// </summary>
     public event Action<TyphonRuntime, TickOutcome> OnTickAborted;
 
@@ -357,6 +362,11 @@ public sealed partial class TyphonRuntime : IDisposable
     /// orderly stop and the wrong thing after a fatal tick: the abort means the simulation is logically incomplete, so committing a final round of shutdown
     /// writes on top of it would persist state derived from a tick that never finished. Everything else — subscription server, profiler, scheduler — is
     /// torn down exactly as in <see cref="Shutdown"/>.
+    /// <para>
+    /// <b>Neither this nor <see cref="Shutdown"/> is a quiescence point.</b> Both stop new ticks; neither waits for the tick in flight. The expected caller
+    /// is an <see cref="OnTickAborted"/> handler, which runs on the tick thread — so this typically returns into the very tick it is stopping, which then
+    /// finishes and posts its accounting. Dispose the runtime when you need "nothing is running": <see cref="Dispose"/> joins the tick thread.
+    /// </para>
     /// </remarks>
     public void FatalStop() => StopInternal(false);
 

--- a/test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs
@@ -331,25 +331,42 @@ public class DagSchedulerTests
     [Test]
     public void Shutdown_Clean()
     {
-        using var scheduler = NewDag(workerCount: 4)
+        var scheduler = NewDag(workerCount: 4)
             .CallbackSystem("A", _ => { })
             .Build(_registry.Runtime);
-        scheduler.Start();
-        SpinWait.SpinUntil(() => scheduler.CurrentTickNumber >= 3, TimeSpan.FromSeconds(5));
-        scheduler.Shutdown();
 
-        // Shutdown() signals and JOINS the workers, but _currentTickNumber++ lives in the tick's telemetry finalizer, which runs on the TIMER thread — so the
-        // tick already in flight when Shutdown() was called can land its increment just after Shutdown() returns. Pinning the baseline immediately raced that
-        // last increment and failed with "Expected: 346 But was: 347" (1 run in 10 pinned to 3 cores). Let the in-flight tick's accounting settle, THEN pin
-        // the baseline. The property under test — that no FURTHER ticks execute — is unaffected and genuinely holds: a probe measured delta 0 across 9 trials
-        // even with a 1 s observation window, so the timer thread stops producing ticks even though only Dispose() actually stops the thread.
-        Thread.Sleep(50);
+        try
+        {
+            scheduler.Start();
+            SpinWait.SpinUntil(() => scheduler.CurrentTickNumber >= 3, TimeSpan.FromSeconds(5));
+            scheduler.Shutdown();
 
-        // Verify the scheduler stopped (no more ticks)
-        var tickAfterShutdown = scheduler.CurrentTickNumber;
-        Thread.Sleep(50);
-        Assert.That(scheduler.CurrentTickNumber, Is.EqualTo(tickAfterShutdown),
-            "No more ticks should execute after shutdown");
+            // Shutdown() is NOT a quiescence point, and this pins exactly how far it falls short rather than sleeping past the gap. It signals and joins the
+            // WORKERS, but the tick already past ExecuteCallbacks' entry gate keeps running on the TIMER thread, and _currentTickNumber++ is the last
+            // statement of that tick's telemetry finalizer. So the counter can advance by ONE after Shutdown() returns — and by no more, because
+            // _workerShutdown is published before the join, so every later tick early-returns at the gate. Asserting equality here is what made this test
+            // flaky: "Expected: 346 But was: 347", 1 run in 10 pinned to 3 cores (#689). The earlier fix slept 50 ms first and pinned the baseline after;
+            // that hid the one-tick advance instead of stating it, which is how the Shutdown() doc came to claim the counter was stable on return (#404).
+            var afterShutdown = scheduler.CurrentTickNumber;
+
+            // Deliberate observation window, not a synchronisation shortcut: the property is the ABSENCE of further ticks, so there is no event to wait on.
+            Thread.Sleep(50);
+
+            Assert.That(scheduler.CurrentTickNumber - afterShutdown, Is.InRange(0L, 1L),
+                "Shutdown() must let at most the in-flight tick post its accounting, and no further tick may execute");
+
+            // Dispose() IS the quiescence point — base.Dispose() -> StopTimerThread() joins the timer thread, so nothing can post after it returns.
+            scheduler.Dispose();
+            var afterDispose = scheduler.CurrentTickNumber;
+            Thread.Sleep(50);
+
+            Assert.That(scheduler.CurrentTickNumber, Is.EqualTo(afterDispose),
+                "No tick accounting may land after Dispose() has joined the timer thread");
+        }
+        finally
+        {
+            scheduler.Dispose();
+        }
     }
 
     // Regression: a scheduler lifecycle must not leave a thread running. Shutdown() bumps _tickGeneration — the same field workers use to detect a new tick —

--- a/test/Typhon.Engine.Tests/Runtime/StrictTickAbortRuntimeTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/StrictTickAbortRuntimeTests.cs
@@ -29,6 +29,15 @@ class StrictTickAbortRuntimeTests : TestBase<StrictTickAbortRuntimeTests>
         SystemExceptionPolicy = SystemExceptionPolicy.AbortTickAndStop,
     };
 
+    // WorkerCount 1 puts the whole tick inline on the timer thread (ExecuteTickSingleThreaded), which is the shape the re-entrancy test below needs — and
+    // the shape the #404 report was filed against.
+    private static RuntimeOptions StrictSingleWorker() => new()
+    {
+        WorkerCount = 1,
+        BaseTickRate = 1000,
+        SystemExceptionPolicy = SystemExceptionPolicy.AbortTickAndStop,
+    };
+
     [Test]
     public void AbortedTick_StillRunsFenceAndFlush()
     {
@@ -82,6 +91,52 @@ class StrictTickAbortRuntimeTests : TestBase<StrictTickAbortRuntimeTests>
         Assert.That(captured.FailedSystemName, Is.EqualTo("Thrower"), "the first failing system must be named");
         Assert.That(captured.FailedSystemException, Is.TypeOf<InvalidOperationException>());
         Assert.That(runtime.LastTickOutcome.FailedSystemIndex, Is.GreaterThanOrEqualTo(0));
+    }
+
+    // The documented response to OnTickAborted is FatalStop(), and the handler runs on the TICK thread, inside the tick — so that call re-enters the
+    // scheduler's shutdown from the very thread it is stopping. Two properties fall out, and both are contract rather than accident (#404):
+    //
+    //   1. FatalStop() must RETURN, promptly. Nothing may join the tick thread from this path — that would be a self-join. StopTimerThread()'s join is
+    //      bounded at 2 s, so implementing #404's original action ("Shutdown() should stop+join the timer thread") without a re-entrancy branch turns every
+    //      fatal stop into a 2 s stall that returns false and changes nothing. The 1 s bound below is what reddens if someone does that.
+    //   2. CurrentTickNumber advances EXACTLY once after FatalStop() returns: the aborted tick resumes where the handler left it and runs its telemetry
+    //      finalizer, whose last statement is the increment. Here the advance is guaranteed, not merely possible — which is what the Shutdown() doc denied
+    //      when it promised the counter was "stable once this returns".
+    [Test]
+    public void FatalStopFromAbortHandler_ReturnsWithoutSelfJoin_AndCostsExactlyOneMoreTick()
+    {
+        long tickInsideHandler = -1;
+        var fatalStopElapsed = TimeSpan.MaxValue;
+        using var handlerDone = new ManualResetEventSlim(false);
+
+        using var dbe = SetupEngine();
+        using var runtime = TyphonRuntime.Create(dbe, schedule =>
+        {
+            schedule.PublicTrack.DeclareDag("Test").CallbackSystem("Thrower", _ => throw new InvalidOperationException("boom"));
+        }, StrictSingleWorker());
+
+        runtime.OnTickAborted += (r, _) =>
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            r.FatalStop();
+            sw.Stop();
+
+            fatalStopElapsed = sw.Elapsed;
+            // Read INSIDE the handler: we are still within the aborted tick, so its increment has not run yet.
+            Volatile.Write(ref tickInsideHandler, r.CurrentTickNumber);
+            handlerDone.Set();
+        };
+
+        runtime.Start();
+        Assert.That(handlerDone.Wait(TimeSpan.FromSeconds(5)), Is.True, "the abort handler must run");
+
+        // Deliberate observation window: let the aborted tick post its accounting, and prove nothing follows it.
+        Thread.Sleep(50);
+
+        Assert.That(fatalStopElapsed, Is.LessThan(TimeSpan.FromSeconds(1)),
+            "FatalStop() from the tick thread must not join the tick thread — a self-join would stall for StopTimerThread's 2 s bound");
+        Assert.That(runtime.CurrentTickNumber, Is.EqualTo(Volatile.Read(ref tickInsideHandler) + 1),
+            "the aborted tick posts its own accounting after FatalStop() returns — exactly one advance, and no further tick");
     }
 
     [Test]


### PR DESCRIPTION
Fixes #404

`DagScheduler.Shutdown`'s XML doc claimed `CurrentTickNumber` was stable once it returned. It is not — and the mechanism was already documented in a test comment 700 lines away, which is how the contradiction survived.

Reported externally on #404 ([comment](https://github.com/Log2n-io/Typhon/issues/404#issuecomment-5295894631)); the report is correct, and understates itself.

## The defect

`Shutdown()` signals `_workerShutdown`, bumps the generation, joins the workers. The `_workerShutdown` gate in `ExecuteCallbacks` (`:396`) is at tick **entry**, so a tick already past it runs to completion on the timer thread — and `_currentTickNumber++` is the last statement of that tick's telemetry finalizer (`DagScheduler.Telemetry.cs:156`). The counter can advance by one after `Shutdown()` returns, and by no more, since `_workerShutdown` is published before the join.

On the `OnTickAborted` path it is not a race but a certainty. That event fires at `TyphonRuntime.cs:2105`, inside `OnTickEndInternal` — which **is** the `TickEndCallback` invoked at `DagScheduler.cs:860`, six lines before `ComputeAndRecordTelemetry` — and its documented response is `FatalStop()`. So `Shutdown()` routinely runs **on the timer thread, inside the tick it is stopping**, and returns straight back into it.

## Why the issue's original action item was dropped

"Have `Shutdown()` stop + join the timer thread" is a **self-join** on that path: `StopTimerThread`'s 2 s bound turns it into a stall that returns `false` and changes nothing, after which the tick completes and increments anyway. The doc fix would not even be delivered by the code fix.

The property the issue wanted is already held: `TyphonRuntime.StopInternal` disposes nothing, and `Dispose()` joins the timer thread *before* disposing the per-thread accessors. #404 has been rewritten to record this.

## What changed

Docs state the guarantee instead of joining for it — `Shutdown`/`FatalStop` stop new ticks and are **not** quiescence points, `Dispose()` is; `OnTickAborted`'s "after the tick has fully drained" means every system ran or was skipped, not that the tick is over, so the handler is documented as running inside the tick and told not to block.

Tests:

- `DagSchedulerTests.Shutdown_Clean` — its `Thread.Sleep(50)` was added by #689 (after `Expected: 346 But was: 347`) to hide this exact advance behind a settle-then-baseline workaround. The sleep is now the assertion: at most one advance after `Shutdown()`, none after `Dispose()`.
- `StrictTickAbortRuntimeTests.FatalStopFromAbortHandler_ReturnsWithoutSelfJoin_AndCostsExactlyOneMoreTick` — **new**, covering the reported path: `FatalStop()` from inside `OnTickAborted` at `WorkerCount=1`, asserting the counter advances **exactly** once, and bounding `FatalStop()` at 1 s so a future self-join reddens instead of silently costing 2 s.

The false line came from #690, which correctly replaced "waits for the current tick to finish" and introduced "stable once this returns" on the way past.

## Verification

`bash scripts/pre-push.sh` — all gate-equivalent checks passed: policy scripts, engine suite Release (5445 passed / 0 failed), Workbench suite Release (662 passed / 0 failed). `SchedulerLifecycle_RacingShutdownAgainstTick_LeavesNoRunningThread` (#690's `Sensitive` guard) unaffected.

Not covered locally: shard contention and the serial `Sensitive` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmLHw4QbBCE6Cp97xu2w9Y