### PR TITLE
#805 On-demand tick capture, and live attach as a capability of a paused database session

### DIFF
--- a/src/Typhon.Engine/Profiler/internals/ProfilerBootstrap.cs
+++ b/src/Typhon.Engine/Profiler/internals/ProfilerBootstrap.cs
@@ -185,9 +185,24 @@ internal static class ProfilerBootstrap
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>Deliberately narrow.</b> An explicit <c>Typhon:Profiler:Trace</c> path still means exactly what it meant before, and a live-only session already
-    /// <i>has</i> a destination — the <c>LivePort &lt; 0</c> term is what keeps this from bolting a file exporter onto one. The default fills an absent
-    /// destination; it never adds a second.
+    /// <b>Deliberately narrow.</b> An explicit <c>Typhon:Profiler:Trace</c> path still means exactly what it meant before: the default fills an absent
+    /// destination, it never overrides a chosen one.
+    /// </para>
+    /// <para>
+    /// <b>A configured live port suppresses it.</b> <c>Live</c> and <c>Trace</c> are independent output channels — that is the whole shape of
+    /// <c>typhon telemetry</c> — so asking for one must never silently produce the other. A live port is a request to <i>watch</i>; turning it into a
+    /// multi-gigabyte file the caller never asked for is a decision the tool does not get to make on their behalf.
+    /// </para>
+    /// <para>
+    /// This is load-bearing for on-demand tick capture (#805), not merely tidy. That feature exists so an operator can record a chosen window and store
+    /// nothing else; the engine keeps emitting every tick over the wire and the Workbench discards what was not armed. A default file destination here
+    /// defeats it completely and invisibly: the operator records 100 ticks, and the engine writes a complete capture of the entire run beside the database
+    /// anyway. Measured on a 2,000-entity shard: <b>25.84 MB written against a 1.04 MB captured window</b>.
+    /// </para>
+    /// <para>
+    /// An explicit <see cref="ProfilerLaunchConfig.TraceFilePath"/> still wins, so wanting both is one setting away
+    /// (<c>typhon telemetry trace &lt;path&gt;</c>). The cost of live-only is that CPU sampling does not run — it is file-mode only — which is a visible,
+    /// logged consequence of a choice the user made, not a silent one made for them.
     /// </para>
     /// <para>
     /// Pruning happens <b>here</b>, in whatever process is about to write a capture, precisely because the Workbench is not always present — a game server, a
@@ -198,6 +213,11 @@ internal static class ProfilerBootstrap
     /// </remarks>
     internal static ProfilerLaunchConfig ApplyDefaultCaptureDestination(TyphonRuntime runtime, ProfilerLaunchConfig config)
     {
+        // A configured live port suppresses the default file. Live and Trace are independent channels: a request to
+        // WATCH must not silently produce a file the caller never asked for. This is what makes on-demand tick capture
+        // (#805) mean anything — an operator who records 100 ticks must not find a complete capture of the whole run
+        // written beside the database regardless. An explicit TraceFilePath still wins, so wanting both is one setting
+        // away; SuppressCapture still wins over everything.
         if (config == null || config.SuppressCapture || config.TraceFilePath != null || config.LivePort >= 0)
         {
             return config;

--- a/src/Typhon.Engine/Storage/internals/PagedMMF.cs
+++ b/src/Typhon.Engine/Storage/internals/PagedMMF.cs
@@ -562,7 +562,7 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
         try
         {
             File.WriteAllText(_lockFilePath, DatabaseLockFile.SerializeLock(
-                Environment.ProcessId, DateTimeOffset.UtcNow, Environment.MachineName, Options.YieldableLock));
+                Environment.ProcessId, DateTimeOffset.UtcNow, Environment.MachineName, Options.YieldableLock, ResolveAdvertisedProfilerEndpoint()));
 
             // Only now may this instance ever delete that file — see ReleaseLockFile. A failed write below leaves this false,
             // so an instance that never owned a lock can never remove one.
@@ -651,6 +651,29 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
     /// the very collision the lock exists to report destroyed the evidence of itself: subsequent openers saw an unlocked
     /// database and fell through to the OS sharing violation with no idea who held it.</para>
     /// </summary>
+    /// <summary>
+    /// The <c>host:port</c> this process's live profiler can be reached at, for the lock file to advertise, or
+    /// <c>null</c> when no live port is configured.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Lets an observer that has the database — the Workbench opening a bundle its holder is using — discover where to
+    /// watch it, without the user retyping an endpoint they never chose. Read from the resolved launch config, which
+    /// <see cref="TelemetryConfig"/> settles at class load from <c>typhon.telemetry.json</c> plus environment.
+    /// </para>
+    /// <para>
+    /// <b>Intent, not liveness.</b> The lock is written when the database opens, which can precede the TCP listener
+    /// binding; a host that overrides the port in code after this point is also not reflected. Consumers treat a refused
+    /// connect as "not watchable right now", so the failure mode of being early or wrong is a retry, not a lie that
+    /// matters.
+    /// </para>
+    /// </remarks>
+    private static string ResolveAdvertisedProfilerEndpoint()
+    {
+        var port = TelemetryConfig.ProfilerLaunch?.LivePort ?? -1;
+        return port >= 0 ? $"localhost:{port}" : null;
+    }
+
     private void ReleaseLockFile()
     {
         if (!_lockFileOwned)

--- a/src/Typhon.Engine/Storage/public/DatabaseLockFile.cs
+++ b/src/Typhon.Engine/Storage/public/DatabaseLockFile.cs
@@ -60,7 +60,26 @@ public static class DatabaseLockFile
     /// <c>true</c> only when the holder explicitly advertised it. <b>Absent means false</b>, so a lock written by an
     /// older build — or by any normal engine — is never mistaken for one that will release on request.
     /// </param>
-    public readonly record struct LockInfo(int Pid, string MachineName, DateTimeOffset StartedAt, bool Yieldable);
+    /// <param name="ProfilerEndpoint">
+    /// Where the holder's live profiler can be reached (<c>host:port</c>), or <c>null</c> when it runs without one.
+    /// <b>Absent means null</b>, on the same reasoning as <paramref name="Yieldable"/>: a lock from an older build must
+    /// never be read as offering something it does not have.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// <b>Why the profiler endpoint rides here.</b> An observer that has the database — the Workbench opening a bundle
+    /// its holder is using — knows <i>who</i> holds it but not <i>where to watch</i> it. The holder knows its own live
+    /// port. This file is the one thing they already share, so the link is drawn database → engine, which is the
+    /// direction the user arrives from. Putting the database's identity on the profiler's wire instead would answer the
+    /// same question backwards, and would cost a wire-format change.
+    /// </para>
+    /// <para>
+    /// It is an advertisement of <i>intent</i>, not a liveness proof: the lock is written when the database opens, which
+    /// may precede the listener actually binding. A consumer must treat a refused connect as "not watchable right now"
+    /// rather than as a contradiction.
+    /// </para>
+    /// </remarks>
+    public readonly record struct LockInfo(int Pid, string MachineName, DateTimeOffset StartedAt, bool Yieldable, string ProfilerEndpoint);
 
     /// <summary>A claim in flight on a yieldable database.</summary>
     /// <param name="Pid">Process id of the claimant.</param>
@@ -89,14 +108,28 @@ public static class DatabaseLockFile
     /// <param name="startedAt">When the holder acquired the database.</param>
     /// <param name="machineName">Machine the holder runs on.</param>
     /// <param name="yieldable">Whether this holder will release the database on request.</param>
-    public static string SerializeLock(int pid, DateTimeOffset startedAt, string machineName, bool yieldable) =>
-        JsonSerializer.Serialize(new
-        {
-            pid,
-            startedAt = startedAt.ToString("o"),
-            machineName,
-            yieldable,
-        });
+    /// <param name="profilerEndpoint">
+    /// <c>host:port</c> of this holder's live profiler, or <c>null</c> when it runs without one. Omitted from the JSON
+    /// when null rather than written as <c>null</c>, so a lock from a holder with no profiler is byte-identical to one
+    /// written before this field existed.
+    /// </param>
+    public static string SerializeLock(int pid, DateTimeOffset startedAt, string machineName, bool yieldable, string profilerEndpoint = null) =>
+        profilerEndpoint == null
+            ? JsonSerializer.Serialize(new
+            {
+                pid,
+                startedAt = startedAt.ToString("o"),
+                machineName,
+                yieldable,
+            })
+            : JsonSerializer.Serialize(new
+            {
+                pid,
+                startedAt = startedAt.ToString("o"),
+                machineName,
+                yieldable,
+                profilerEndpoint,
+            });
 
     /// <summary>
     /// Reads the lock file. Returns <c>false</c> for absent, empty, unparseable or truncated files.
@@ -132,8 +165,17 @@ public static class DatabaseLockFile
             // Absent ⇒ false. This default is what keeps every pre-#621 lock file, and every ordinary engine's lock,
             // safe from being treated as willing to yield.
             var yieldable = root.TryGetProperty("yieldable", out var y) && y.ValueKind == JsonValueKind.True;
+            // Absent ⇒ null, for the same reason yieldable defaults false: a lock written before this field existed must
+            // never be read as advertising a profiler that is not there.
+            var profilerEndpoint = root.TryGetProperty("profilerEndpoint", out var pe) && pe.ValueKind == JsonValueKind.String
+                ? pe.GetString()
+                : null;
+            if (string.IsNullOrWhiteSpace(profilerEndpoint))
+            {
+                profilerEndpoint = null;
+            }
 
-            info = new LockInfo(root.GetProperty("pid").GetInt32(), machine, startedAt, yieldable);
+            info = new LockInfo(root.GetProperty("pid").GetInt32(), machine, startedAt, yieldable, profilerEndpoint);
             return true;
         }
         catch (Exception ex) when (IsExpectedIoOrFormatFailure(ex))

--- a/src/Typhon.Shell/Commands/TelemetryCommands.cs
+++ b/src/Typhon.Shell/Commands/TelemetryCommands.cs
@@ -175,6 +175,92 @@ internal sealed class TelemetryTraceCommand : Command<TelemetryTraceSettings>
     private static bool IsClearWord(string s) => Array.Exists(ClearWords, w => string.Equals(w, s, StringComparison.OrdinalIgnoreCase));
 }
 
+internal sealed class TelemetryLiveSettings : TelemetryFileSettings
+{
+    [CommandArgument(0, "[port]")]
+    [Description("TCP port for live attach (e.g. 9100), or 'off' to remove it.")]
+    public string Port { get; set; }
+
+    [CommandOption("--wait <MS>")]
+    [Description("Block startup up to this many ms waiting for the first viewer to connect.")]
+    public int? WaitMs { get; set; }
+
+    [CommandOption("--clear")]
+    [Description("Remove the live channel.")]
+    public bool Clear { get; set; }
+}
+
+/// <summary>
+/// <c>typhon telemetry live &lt;port&gt;</c> — the live TCP channel (<c>Typhon:Profiler:Live</c>), sibling of
+/// <see cref="TelemetryTraceCommand"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A separate verb rather than a node in <c>telemetry edit</c> on purpose: that editor is a tri-state tree over the
+/// generated flag catalog, where every node is inherit / on / off. A port is none of those, and special-casing a typed
+/// field into it would trade a uniform control over 200-odd flags for a form.
+/// </para>
+/// <para>
+/// This exists because the port stopped being a private launch detail: the engine publishes it in the database's
+/// <c>db.lock</c>, so a Workbench opening a bundle its application holds can discover where to watch. A value that two
+/// processes agree on belongs in the tool that writes the file, not in hand-edited JSON.
+/// </para>
+/// </remarks>
+internal sealed class TelemetryLiveCommand : Command<TelemetryLiveSettings>
+{
+    protected override int Execute(CommandContext context, TelemetryLiveSettings settings, CancellationToken cancellationToken)
+    {
+        var model = TelemetryFile.Load(TelemetryCommandSupport.FilePath(settings.File));
+        var port = settings.Port?.Trim();
+
+        // Same footgun as `trace`: a bare `live off` must remove the channel, not fail to parse and leave the previous
+        // port armed. Handled here rather than left to int.TryParse so the two verbs behave identically.
+        if (settings.Clear || (port != null && IsClearWord(port)))
+        {
+            model.ClearLive();
+            TelemetryCommandSupport.PrintSaved(model, null, "cleared live attach");
+            return 0;
+        }
+
+        if (string.IsNullOrEmpty(port))
+        {
+            // No argument reads as "show me", not as an error: it is the question someone types first.
+            if (model.LivePort is { } current)
+            {
+                var wait = model.LiveWaitMs is { } w ? $", waits up to {w} ms for a viewer" : "";
+                AnsiConsole.MarkupLine($"[green]live attach on port {current}[/][grey]{Markup.Escape(wait)}[/]");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[grey]live attach not configured[/]");
+                AnsiConsole.MarkupLine("  [grey]typhon telemetry live 9100[/]");
+            }
+            return 0;
+        }
+
+        if (!int.TryParse(port, out var parsed) || parsed < 1 || parsed > 65535)
+        {
+            AnsiConsole.MarkupLine($"[red]Not a TCP port:[/] {Markup.Escape(port)} [grey](expected 1-65535, or 'off')[/]");
+            return 1;
+        }
+
+        if (settings.WaitMs is { } ms && ms < 0)
+        {
+            AnsiConsole.MarkupLine("[red]--wait must be zero or positive.[/]");
+            return 1;
+        }
+
+        model.SetLive(parsed, settings.WaitMs);
+        var suffix = settings.WaitMs is { } set ? $" (wait {set} ms)" : "";
+        TelemetryCommandSupport.PrintSaved(model, null, $"live → port {parsed}{suffix}");
+        return 0;
+    }
+
+    private static readonly string[] ClearWords = ["clear", "off", "none", "disable", "disabled", "remove", "false"];
+
+    private static bool IsClearWord(string s) => Array.Exists(ClearWords, w => string.Equals(w, s, StringComparison.OrdinalIgnoreCase));
+}
+
 internal sealed class TelemetryDisableCommand : Command<TelemetryPathSettings>
 {
     protected override int Execute(CommandContext context, TelemetryPathSettings settings, CancellationToken cancellationToken)
@@ -238,6 +324,11 @@ internal sealed class TelemetryEffectiveCommand : Command<TelemetryEffectiveSett
             .Select(i => all[i].Path.Length == 0 ? "Profiler" : all[i].Path)
             .ToList();
 
+        // "What would actually emit" has two halves, and the flags are only one of them: events that fire with nowhere
+        // to go emit nothing at all. Reporting the output channels here is what makes the answer complete — and a
+        // profiler with flags on but no Trace and no Live is a specific, easy mistake worth naming out loud.
+        ReportOutputChannels(model);
+
         if (on.Count == 0)
         {
             AnsiConsole.MarkupLine("[grey]No telemetry effectively enabled.[/]");
@@ -249,6 +340,28 @@ internal sealed class TelemetryEffectiveCommand : Command<TelemetryEffectiveSett
             AnsiConsole.MarkupLine("  [green]" + Markup.Escape(p) + "[/]");
         }
         return 0;
+    }
+
+    private static void ReportOutputChannels(TelemetryFile model)
+    {
+        var hasTrace = !string.IsNullOrEmpty(model.TracePath);
+        var hasLive = model.LivePort.HasValue;
+
+        if (hasTrace)
+        {
+            AnsiConsole.MarkupLine($"[green]trace file[/] → {Markup.Escape(model.TracePath)}");
+        }
+        if (hasLive)
+        {
+            var wait = model.LiveWaitMs is { } w ? $" (waits up to {w} ms for a viewer)" : "";
+            AnsiConsole.MarkupLine($"[green]live attach[/] → port {model.LivePort.Value}{Markup.Escape(wait)}");
+        }
+        if (!hasTrace && !hasLive)
+        {
+            AnsiConsole.MarkupLine("[yellow]No output channel[/] [grey]— no trace file and no live port, so nothing is recorded anywhere.[/]");
+            AnsiConsole.MarkupLine("  [grey]typhon telemetry trace captures/app.typhon-trace   ·   typhon telemetry live 9100[/]");
+        }
+        AnsiConsole.WriteLine();
     }
 }
 

--- a/src/Typhon.Shell/Program.cs
+++ b/src/Typhon.Shell/Program.cs
@@ -115,6 +115,7 @@ internal static class Program
                     tel.AddCommand<TelemetryEnableCommand>("enable").WithDescription("Set a flag (or subtree root) explicitly on.");
                     tel.AddCommand<TelemetryDisableCommand>("disable").WithDescription("Set a flag explicitly off.");
                     tel.AddCommand<TelemetryTraceCommand>("trace").WithDescription("Set/clear the profiler trace output file (Typhon:Profiler:Trace).");
+                    tel.AddCommand<TelemetryLiveCommand>("live").WithDescription("Set/clear the live attach TCP port (Typhon:Profiler:Live).");
                     tel.AddCommand<TelemetryResetCommand>("reset").WithDescription("Remove an explicit flag (back to inherit).");
                     tel.AddCommand<TelemetryEffectiveCommand>("effective").WithDescription("Show what would actually emit.");
                     tel.AddCommand<TelemetryPresetCommand>("preset").WithDescription("Apply a curated preset bundle.");

--- a/src/Typhon.Shell/Telemetry/TelemetryEditor.cs
+++ b/src/Typhon.Shell/Telemetry/TelemetryEditor.cs
@@ -30,6 +30,11 @@ internal sealed class TelemetryEditor
     // `typhon telemetry trace <path>`; the editor toggles the channel on/off with this sensible default.
     private const string DefaultTracePath = "captures/app.typhon-trace";
 
+    // Default port when arming live attach from the editor (F4), mirroring how F3 arms a trace with a default path.
+    // Matches ProfilerLaunchConfig.DefaultLivePort, which is also what the Workbench's Attach dialog prefills — three
+    // places agreeing on 9100 is the difference between "it just connects" and "why is it not connecting".
+    private const int DefaultLivePort = 9100;
+
     // Transparent normal background (terminal shows through); dark selection bar keeps coloured text readable.
     private Color _bgNormal;
     private Color _bgFocus;
@@ -91,10 +96,22 @@ internal sealed class TelemetryEditor
             };
             traceLabel.SetScheme(Fg(string.IsNullOrEmpty(_model.TracePath) ? _fgDefault : On));
 
+            // The second output channel, on the same footing. Since #805 the live port is published in the database's
+            // db.lock, so turning it on here is what lets the Workbench discover this app and offer to watch it.
+            var liveLabel = new Label
+            {
+                X = 1,
+                Y = Pos.Bottom(traceLabel),
+                Width = Dim.Fill(1),
+                Height = 1,
+                Text = LiveStatusText(),
+            };
+            liveLabel.SetScheme(Fg(_model.LivePort.HasValue ? On : _fgDefault));
+
             var tree = new FlagTree
             {
                 X = 0,
-                Y = Pos.Bottom(traceLabel),
+                Y = Pos.Bottom(liveLabel),
                 Width = Dim.Fill(),
                 Height = Dim.Fill(4), // leave 4 rows for the selection info + 2 legend lines
             };
@@ -139,7 +156,9 @@ internal sealed class TelemetryEditor
                 ("Space/Enter", Footgun),
                 (" cycle     ", _fgDefault),
                 ("F3", On),
-                (" trace on/off     ", _fgDefault),
+                (" trace     ", _fgDefault),
+                ("F4", On),
+                (" live     ", _fgDefault),
                 ("F2", On),
                 (" save & quit     ", _fgDefault),
                 ("Esc", Off),
@@ -163,6 +182,7 @@ internal sealed class TelemetryEditor
             };
             tree.Cancel = () => app.RequestStop();
             tree.ToggleTrace = () => ToggleTrace(traceLabel);
+            tree.ToggleLive = () => ToggleLive(liveLabel);
             tree.SelectionChanged += (_, e) =>
             {
                 if (e.NewValue is FlagRef r)
@@ -178,7 +198,7 @@ internal sealed class TelemetryEditor
                 Height = Dim.Fill(),
             };
             win.SetScheme(transparent);
-            win.Add(traceLabel, tree, selInfo);
+            win.Add(traceLabel, liveLabel, tree, selInfo);
             foreach (var v in legendState)
             {
                 win.Add(v);
@@ -357,6 +377,33 @@ internal sealed class TelemetryEditor
             ? $"Trace output: (off — no trace file is written)   ·   F3 to enable → {DefaultTracePath}"
             : $"Trace output: {_model.TracePath}   (a trace is written each run)   ·   F3 to disable";
 
+    private string LiveStatusText()
+        => _model.LivePort is { } port
+            ? $"Live attach:  port {port}   (the Workbench can watch this app)   ·   F4 to disable"
+            : $"Live attach:  (off — nothing to attach to)   ·   F4 to enable → port {DefaultLivePort}";
+
+    /// <summary>
+    /// Toggle the live TCP channel, the second output axis the flag tree cannot reach.
+    /// </summary>
+    /// <remarks>
+    /// Arms <see cref="DefaultLivePort"/> when off and clears when on, exactly as F3 does for the trace file. A custom
+    /// port is still <c>typhon telemetry live &lt;port&gt;</c> — the editor toggles channels, it does not author values.
+    /// </remarks>
+    private void ToggleLive(Label label)
+    {
+        if (_model.LivePort.HasValue)
+        {
+            _model.ClearLive();
+        }
+        else
+        {
+            _model.SetLive(DefaultLivePort);
+        }
+        label.Text = LiveStatusText();
+        label.SetScheme(Fg(_model.LivePort.HasValue ? On : _fgDefault));
+        label.SetNeedsDraw();
+    }
+
     /// <summary>Toggle the profiler trace output channel: arm it with <see cref="DefaultTracePath"/> when off, clear it
     /// when on. This is the axis the flag tree can't reach — clearing it is what actually stops a session from tracing.</summary>
     private void ToggleTrace(Label label)
@@ -390,6 +437,7 @@ internal sealed class TelemetryEditor
         public Action SaveQuit;
         public Action Cancel;
         public Action ToggleTrace;
+        public Action ToggleLive;
 
         protected override bool OnKeyDown(Key key)
         {
@@ -404,6 +452,11 @@ internal sealed class TelemetryEditor
             if (key == Key.F3)
             {
                 ToggleTrace?.Invoke();
+                return true;
+            }
+            if (key == Key.F4)
+            {
+                ToggleLive?.Invoke();
                 return true;
             }
             if (key == Key.F2)

--- a/src/Typhon.Shell/Telemetry/TelemetryFile.cs
+++ b/src/Typhon.Shell/Telemetry/TelemetryFile.cs
@@ -26,11 +26,17 @@ internal sealed class TelemetryFile
     // Typhon:Profiler:Trace — a string output path, not a gate flag; null when unset.
     private string _tracePath;
 
-    private TelemetryFile(string path, Dictionary<string, bool> ov, string tracePath)
+    // Typhon:Profiler:Live / :LiveWaitMs — the live TCP channel. Scalars like Trace, not gate flags.
+    private int? _livePort;
+    private int? _liveWaitMs;
+
+    private TelemetryFile(string path, Dictionary<string, bool> ov, string tracePath, int? livePort, int? liveWaitMs)
     {
         Path = path;
         _explicit = ov;
         _tracePath = tracePath;
+        _livePort = livePort;
+        _liveWaitMs = liveWaitMs;
     }
 
     public IReadOnlyDictionary<string, bool> Explicit => _explicit;
@@ -45,11 +51,48 @@ internal sealed class TelemetryFile
     /// <summary>Remove the profiler trace output path.</summary>
     public void ClearTrace() => _tracePath = null;
 
+    /// <summary>
+    /// The explicit <c>Typhon:Profiler:Live</c> TCP port, or <c>null</c> when unset. Like <see cref="TracePath"/>,
+    /// declaring it activates profiling on its own — an output channel is what makes the profiler live.
+    /// </summary>
+    /// <remarks>
+    /// Since #805 this is not merely a launch detail: the engine publishes it in the database's <c>db.lock</c>, so the
+    /// Workbench opening a bundle its application holds can discover where to watch without being told. That makes the
+    /// port a contract between two processes, which is why it belongs in the tool that writes this file rather than in
+    /// hand-edited JSON.
+    /// </remarks>
+    public int? LivePort => _livePort;
+
+    /// <summary>
+    /// The explicit <c>Typhon:Profiler:LiveWaitMs</c> — how long startup blocks waiting for the first viewer to
+    /// connect, or <c>null</c> when unset. Meaningless without <see cref="LivePort"/>.
+    /// </summary>
+    public int? LiveWaitMs => _liveWaitMs;
+
+    /// <summary>Set the live TCP port (<c>Typhon:Profiler:Live</c>).</summary>
+    public void SetLive(int port, int? waitMs = null)
+    {
+        _livePort = port;
+        if (waitMs.HasValue)
+        {
+            _liveWaitMs = waitMs;
+        }
+    }
+
+    /// <summary>Remove the live channel, including its wait — a wait without a port configures nothing.</summary>
+    public void ClearLive()
+    {
+        _livePort = null;
+        _liveWaitMs = null;
+    }
+
     /// <summary>Load the file (or an empty model if it does not exist).</summary>
     public static TelemetryFile Load(string path)
     {
         var ov = new Dictionary<string, bool>(StringComparer.Ordinal);
         string tracePath = null;
+        int? livePort = null;
+        int? liveWaitMs = null;
         if (File.Exists(path))
         {
             using var doc = JsonDocument.Parse(File.ReadAllText(path), new JsonDocumentOptions
@@ -65,9 +108,33 @@ internal sealed class TelemetryFile
                 {
                     tracePath = traceEl.GetString();
                 }
+                // Accept a number or a numeric string: the configuration binder stringifies either, and a file written
+                // by hand is as likely to quote the port as not. Anything that is not a number is left unset rather
+                // than coerced — ProfilerLaunchConfig would silently read a junk value as the default port, and a
+                // config tool that quietly rewrites nonsense into 9100 is worse than one that leaves it alone.
+                livePort = ReadInt(profiler, "Live");
+                liveWaitMs = ReadInt(profiler, "LiveWaitMs");
             }
         }
-        return new TelemetryFile(path, ov, tracePath);
+        return new TelemetryFile(path, ov, tracePath, livePort, liveWaitMs);
+    }
+
+    /// <summary>Reads a scalar int property written either as a JSON number or as a numeric string; null otherwise.</summary>
+    private static int? ReadInt(JsonElement parent, string name)
+    {
+        if (!parent.TryGetProperty(name, out var el))
+        {
+            return null;
+        }
+        if (el.ValueKind == JsonValueKind.Number && el.TryGetInt32(out var n))
+        {
+            return n;
+        }
+        if (el.ValueKind == JsonValueKind.String && int.TryParse(el.GetString(), out var s))
+        {
+            return s;
+        }
+        return null;
     }
 
     private static void Collect(JsonElement node, string path, Dictionary<string, bool> ov)
@@ -153,32 +220,58 @@ internal sealed class TelemetryFile
         sb.AppendLine("// everything else inherits (see the telemetry flags reference). Env vars override this file.");
         sb.AppendLine("{");
         sb.AppendLine("  \"Typhon\": {");
-        EmitChildren(root, sb, 2, "Profiler", _tracePath);
+        EmitChildren(root, sb, 2, "Profiler", new OutputChannels(_tracePath, _livePort, _liveWaitMs));
         sb.AppendLine("  }");
         sb.AppendLine("}");
         File.WriteAllText(Path, sb.ToString());
     }
 
-    private static void EmitChildren(EmitNode profilerContent, StringBuilder sb, int indent, string wrapName, string tracePath)
+    /// <summary>
+    /// The profiler's output channels — scalars rather than gate flags, so they are emitted ahead of the flag tree
+    /// rather than within it. Grouped because there are now three: threading them as separate parameters through the
+    /// emitter made the signature say less each time one was added.
+    /// </summary>
+    private readonly record struct OutputChannels(string TracePath, int? LivePort, int? LiveWaitMs)
+    {
+        public bool Any => !string.IsNullOrEmpty(TracePath) || LivePort.HasValue || LiveWaitMs.HasValue;
+    }
+
+    private static void EmitChildren(EmitNode profilerContent, StringBuilder sb, int indent, string wrapName, OutputChannels channels)
     {
         var pad = new string(' ', indent * 2);
         sb.AppendLine(pad + "\"" + wrapName + "\": {");
-        EmitBody(profilerContent, sb, indent + 1, tracePath);
+        EmitBody(profilerContent, sb, indent + 1, channels);
         sb.AppendLine(pad + "}");
     }
 
-    private static void EmitBody(EmitNode node, StringBuilder sb, int indent, string tracePath = null)
+    private static void EmitBody(EmitNode node, StringBuilder sb, int indent, OutputChannels channels = default)
     {
         var pad = new string(' ', indent * 2);
         var kids = node.Children.OrderBy(k => k.Key, StringComparer.Ordinal).ToList();
 
-        // The trace output path (a string, not a gate flag) leads the Profiler body when set. A trailing comma
-        // follows only if an Enabled flag or a child subtree comes after it.
-        if (!string.IsNullOrEmpty(tracePath))
+        // Output channels (strings and numbers, not gate flags) lead the Profiler body when set. A trailing comma
+        // follows each only if something else comes after it — an Enabled flag, a child subtree, or another channel.
+        if (channels.Any)
         {
-            var following = node.HasValue || kids.Count > 0;
-            sb.AppendLine(pad + "// Profiler trace output file — declaring it activates profiling.");
-            sb.AppendLine(pad + "\"Trace\": " + JsonSerializer.Serialize(tracePath) + (following ? "," : ""));
+            var tail = node.HasValue || kids.Count > 0;
+            if (!string.IsNullOrEmpty(channels.TracePath))
+            {
+                var following = tail || channels.LivePort.HasValue || channels.LiveWaitMs.HasValue;
+                sb.AppendLine(pad + "// Profiler trace output file — declaring it activates profiling.");
+                sb.AppendLine(pad + "\"Trace\": " + JsonSerializer.Serialize(channels.TracePath) + (following ? "," : ""));
+            }
+            if (channels.LivePort.HasValue)
+            {
+                var following = tail || channels.LiveWaitMs.HasValue;
+                sb.AppendLine(pad + "// Live TCP port for the Workbench to attach to — also published in the database's db.lock,");
+                sb.AppendLine(pad + "// so opening that database while this app holds it can offer to watch it.");
+                sb.AppendLine(pad + "\"Live\": " + channels.LivePort.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) + (following ? "," : ""));
+            }
+            if (channels.LiveWaitMs.HasValue)
+            {
+                sb.AppendLine(pad + "// Block startup up to this many ms waiting for the first viewer to connect.");
+                sb.AppendLine(pad + "\"LiveWaitMs\": " + channels.LiveWaitMs.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) + (tail ? "," : ""));
+            }
         }
 
         if (node.HasValue)

--- a/test/Typhon.Engine.Tests/Profiler/CaptureDestinationTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/CaptureDestinationTests.cs
@@ -65,10 +65,28 @@ class CaptureDestinationTests : TestBase<CaptureDestinationTests>
             "existing configuration must not change meaning — anyone who set a path already told us where they want it");
     }
 
-    // ── AC3 · a live-only session gains no file exporter ─────────────────────────────────────────────────────
+    // ── AC3 · a live port asks to WATCH, and writes nothing on its own ───────────────────────────────────────
 
+    /// <summary>
+    /// A configured live port suppresses the default file destination.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Live</c> and <c>Trace</c> are independent output channels, so asking for one must not silently produce the
+    /// other. This assertion was briefly inverted during #805 on the reasoning that "a TCP stream leaves nothing
+    /// behind, so the file is complementary". That reasoning ignored what the feature above it is for.
+    /// </para>
+    /// <para>
+    /// On-demand tick capture exists so an operator can record a chosen window and <b>store nothing else</b> — the
+    /// engine keeps emitting every tick over the wire and the Workbench discards what was not armed. A default file
+    /// destination here defeats that completely and invisibly. Measured on a 2,000-entity shard while recording two
+    /// 100-tick windows: <b>25.84 MB written beside the database against a 1.04 MB captured window.</b> The user's
+    /// requirement was explicit — "receive the data and ignore it, but DON'T STORE it" — and a tool does not get to
+    /// decide otherwise on their behalf.
+    /// </para>
+    /// </remarks>
     [Test]
-    public void LiveOnlySession_GetsNoFileDestination()
+    public void LivePort_SuppressesTheDefaultFileDestination()
     {
         using var dbe = SetupEngine();
         using var runtime = CreateIdleRuntime(dbe);
@@ -77,11 +95,27 @@ class CaptureDestinationTests : TestBase<CaptureDestinationTests>
 
         Assert.Multiple(() =>
         {
-            Assert.That(resolved.TraceFilePath, Is.Null, "a live session already has a destination; the default fills an absent one, it does not add a second");
-            Assert.That(resolved.LivePort, Is.EqualTo(9100));
+            Assert.That(resolved.LivePort, Is.EqualTo(9100), "the live port must survive untouched");
+            Assert.That(resolved.TraceFilePath, Is.Null,
+                "asking to watch must not write a complete capture of the whole run — that is exactly what cherry-picked capture exists to avoid");
         });
-        // Deliberately NOT asserting that profilings/ is absent: the runtime this test creates runs its own profiler bootstrap, which (the test project
-        // enables the profiler) may already have created the directory. That would test the fixture's environment, not this decision.
+    }
+
+    /// <summary>
+    /// Wanting both channels is one setting away: an explicit path is honoured alongside a live port, so a user who
+    /// wants the post-mortem file (and CPU sampling, which is file-mode only) says so and gets it.
+    /// </summary>
+    [Test]
+    public void LiveSessionWithAnExplicitPath_KeepsThatPath()
+    {
+        using var dbe = SetupEngine();
+        using var runtime = CreateIdleRuntime(dbe);
+        var explicitPath = Path.Combine(Path.GetTempPath(), "live-and-explicit.typhon-trace");
+
+        var resolved = ProfilerBootstrap.ApplyDefaultCaptureDestination(
+            runtime, new ProfilerLaunchConfig { LivePort = 9100, TraceFilePath = explicitPath });
+
+        Assert.That(resolved.TraceFilePath, Is.EqualTo(explicitPath));
     }
 
     // ── AC4 · no engine, no invention ────────────────────────────────────────────────────────────────────────

--- a/test/Typhon.Engine.Tests/Storage/LockFileProfilerEndpointTests.cs
+++ b/test/Typhon.Engine.Tests/Storage/LockFileProfilerEndpointTests.cs
@@ -1,0 +1,100 @@
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// The lock file advertises where the holder's live profiler can be reached, so an observer that has the database can
+/// discover where to watch it without the user retyping an endpoint they never chose.
+/// </summary>
+/// <remarks>
+/// The property under test is <b>compatibility discipline</b>, not the field itself. <c>yieldable</c> established the
+/// rule this follows: <i>absent means the safe answer</i>, so a lock written by an older build, or by an engine running
+/// without a profiler, can never be read as offering something it does not have. A regression here would make the
+/// Workbench offer a "watch live" action that connects to nothing.
+/// </remarks>
+[TestFixture]
+internal sealed class LockFileProfilerEndpointTests
+{
+    private string _dir;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "typhon-lockfile-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (IOException) { /* best-effort */ }
+    }
+
+    private void WriteLock(string json) => File.WriteAllText(DatabaseLockFile.PathFor(_dir), json);
+
+    [Test]
+    public void EndpointRoundTrips()
+    {
+        WriteLock(DatabaseLockFile.SerializeLock(1234, DateTimeOffset.UtcNow, "HOST", yieldable: false, profilerEndpoint: "localhost:9100"));
+
+        Assert.That(DatabaseLockFile.TryReadLock(_dir, out var info), Is.True);
+        Assert.That(info.ProfilerEndpoint, Is.EqualTo("localhost:9100"));
+    }
+
+    [Test]
+    public void NoProfiler_SerialisesToAPreExistingLockFileShape()
+    {
+        // Byte-identical to what the previous build wrote. An engine with no live profiler must not start emitting a
+        // new field — a null in the file is one more thing every reader has to have an opinion about.
+        var withoutEndpoint = DatabaseLockFile.SerializeLock(7, DateTimeOffset.UnixEpoch, "HOST", yieldable: true);
+
+        Assert.That(withoutEndpoint, Does.Not.Contain("profilerEndpoint"));
+        using var doc = JsonDocument.Parse(withoutEndpoint);
+        Assert.That(doc.RootElement.TryGetProperty("profilerEndpoint", out _), Is.False);
+    }
+
+    [Test]
+    public void LockFromAnOlderBuild_ReadsAsNoProfiler()
+    {
+        // Exactly the shape shipped before this field existed.
+        WriteLock("""{"pid":42,"startedAt":"2026-01-01T00:00:00.0000000+00:00","machineName":"HOST","yieldable":true}""");
+
+        Assert.That(DatabaseLockFile.TryReadLock(_dir, out var info), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(info.Pid, Is.EqualTo(42), "the pre-existing fields must still parse");
+            Assert.That(info.Yieldable, Is.True);
+            Assert.That(info.ProfilerEndpoint, Is.Null, "absent must mean no profiler, never a fabricated endpoint");
+        });
+    }
+
+    [Test]
+    public void BlankOrNonStringEndpoint_ReadsAsNoProfiler()
+    {
+        // A half-written or malformed value must degrade to "no profiler" rather than to an endpoint that cannot connect:
+        // the Workbench would otherwise offer an action that always fails.
+        foreach (var raw in new[] { "\"\"", "\"   \"", "null", "1234", "{}" })
+        {
+            WriteLock($$"""{"pid":9,"startedAt":"2026-01-01T00:00:00.0000000+00:00","machineName":"HOST","yieldable":false,"profilerEndpoint":{{raw}}}""");
+            Assert.That(DatabaseLockFile.TryReadLock(_dir, out var info), Is.True, $"lock with endpoint {raw} must still parse");
+            Assert.That(info.ProfilerEndpoint, Is.Null, $"endpoint {raw} must read as absent");
+        }
+    }
+
+    [Test]
+    public void EndpointDoesNotDisturbTheYieldableDefault()
+    {
+        // The two optional fields must stay independent: advertising a profiler says nothing about willingness to yield.
+        WriteLock("""{"pid":5,"startedAt":"2026-01-01T00:00:00.0000000+00:00","machineName":"HOST","profilerEndpoint":"localhost:9100"}""");
+
+        Assert.That(DatabaseLockFile.TryReadLock(_dir, out var info), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(info.Yieldable, Is.False, "absent yieldable must still default false");
+            Assert.That(info.ProfilerEndpoint, Is.EqualTo("localhost:9100"));
+        });
+    }
+}

--- a/test/Typhon.Shell.Tests/TelemetryLiveChannelTests.cs
+++ b/test/Typhon.Shell.Tests/TelemetryLiveChannelTests.cs
@@ -1,0 +1,179 @@
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using Typhon.Engine;
+using Typhon.Shell.Telemetry;
+
+namespace Typhon.Shell.Tests;
+
+/// <summary>
+/// <c>typhon telemetry live</c> — the live TCP channel (<c>Typhon:Profiler:Live</c>) as a first-class output channel
+/// alongside <c>Trace</c>.
+/// </summary>
+/// <remarks>
+/// The port stopped being a private launch detail when the engine began publishing it in the database's
+/// <c>db.lock</c>: a Workbench opening a bundle its application holds reads it to discover where to watch. A value two
+/// processes agree on has to be settable by the tool that writes the file, and — the assertion that actually matters —
+/// has to survive a round-trip through it unchanged.
+/// </remarks>
+[TestFixture]
+public sealed class TelemetryLiveChannelTests
+{
+    private string _dir;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "typhon-telemetry-live", System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    private string FilePath => Path.Combine(_dir, TelemetryFile.DefaultFileName);
+
+    [Test]
+    public void Live_RoundTrips_AlongsideTraceAndGateFlags()
+    {
+        var model = TelemetryFile.Load(FilePath);
+        model.Set("", true);
+        model.Set("Gauges", true);
+        model.SetTrace("captures/app.typhon-trace");
+        model.SetLive(9100, waitMs: 30_000);
+        model.Save();
+
+        var reloaded = TelemetryFile.Load(FilePath);
+        Assert.Multiple(() =>
+        {
+            Assert.That(reloaded.LivePort, Is.EqualTo(9100));
+            Assert.That(reloaded.LiveWaitMs, Is.EqualTo(30_000));
+            Assert.That(reloaded.TracePath, Is.EqualTo("captures/app.typhon-trace"), "the two channels must coexist");
+            Assert.That(reloaded.TryGetExplicit("Gauges", out var gauges) && gauges, Is.True, "gate flags must survive");
+        });
+    }
+
+    /// <summary>
+    /// The written file must be readable by the engine's own config path, not merely by our loader. A tool that writes
+    /// a shape only it can read is worse than no tool.
+    /// </summary>
+    [Test]
+    public void WhatWeWrite_IsWhatProfilerLaunchConfigReads()
+    {
+        var model = TelemetryFile.Load(FilePath);
+        model.Set("", true);
+        model.SetLive(9433, waitMs: 1_500);
+        model.SetTrace("captures/x.typhon-trace");
+        model.Save();
+
+        var config = new ConfigurationBuilder()
+            .AddJsonFile(FilePath, optional: false)
+            .Build();
+        var launch = ProfilerLaunchConfig.FromConfiguration(config);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(launch.LivePort, Is.EqualTo(9433));
+            Assert.That(launch.LiveWaitMs, Is.EqualTo(1_500));
+            Assert.That(launch.TraceFilePath, Is.EqualTo("captures/x.typhon-trace"));
+            Assert.That(launch.IsActive, Is.True);
+        });
+    }
+
+    [Test]
+    public void ClearLive_RemovesTheWaitToo()
+    {
+        var model = TelemetryFile.Load(FilePath);
+        model.SetLive(9100, waitMs: 5_000);
+        model.ClearLive();
+        model.Save();
+
+        var reloaded = TelemetryFile.Load(FilePath);
+        Assert.Multiple(() =>
+        {
+            Assert.That(reloaded.LivePort, Is.Null);
+            // A wait with no port configures nothing and would read as a stale leftover next time someone opened the file.
+            Assert.That(reloaded.LiveWaitMs, Is.Null, "the wait is meaningless without a port and must go with it");
+        });
+        Assert.That(File.ReadAllText(FilePath), Does.Not.Contain("LiveWaitMs"));
+    }
+
+    [Test]
+    public void UnsetLive_EmitsNothing()
+    {
+        var model = TelemetryFile.Load(FilePath);
+        model.Set("", true);
+        model.Save();
+
+        var text = File.ReadAllText(FilePath);
+        Assert.Multiple(() =>
+        {
+            Assert.That(text, Does.Not.Contain("\"Live\""), "an absent channel must not appear as null");
+            Assert.That(text, Does.Not.Contain("LiveWaitMs"));
+        });
+        Assert.That(TelemetryFile.Load(FilePath).LivePort, Is.Null);
+    }
+
+    /// <summary>
+    /// A hand-written file may quote the port. Accept it — the configuration binder does — rather than silently
+    /// dropping a setting the user can see in their own file.
+    /// </summary>
+    [Test]
+    public void QuotedPort_IsAccepted()
+    {
+        File.WriteAllText(FilePath, """{ "Typhon": { "Profiler": { "Enabled": true, "Live": "9100", "LiveWaitMs": "250" } } }""");
+
+        var model = TelemetryFile.Load(FilePath);
+        Assert.Multiple(() =>
+        {
+            Assert.That(model.LivePort, Is.EqualTo(9100));
+            Assert.That(model.LiveWaitMs, Is.EqualTo(250));
+        });
+    }
+
+    /// <summary>
+    /// A non-numeric value is left unset rather than coerced. <c>ProfilerLaunchConfig</c> would read junk as the default
+    /// port 9100; a config tool that quietly rewrites nonsense into a working port hides the user's typo from them.
+    /// </summary>
+    [Test]
+    public void NonNumericPort_IsLeftUnsetRatherThanCoerced()
+    {
+        File.WriteAllText(FilePath, """{ "Typhon": { "Profiler": { "Enabled": true, "Live": "yes-please" } } }""");
+
+        Assert.That(TelemetryFile.Load(FilePath).LivePort, Is.Null);
+    }
+
+    /// <summary>The emitted JSON must parse. The emitter hand-writes commas, and three optional scalars is where that breaks.</summary>
+    [Test]
+    public void EmittedJson_IsValid_ForEveryCombinationOfChannels()
+    {
+        foreach (var (trace, port, wait, gate) in new[]
+        {
+            ((string)null, (int?)null, (int?)null, false),
+            ("t.typhon-trace", null, null, false),
+            (null, 9100, null, false),
+            (null, 9100, 500, false),
+            ("t.typhon-trace", 9100, 500, false),
+            ("t.typhon-trace", 9100, 500, true),
+            (null, null, null, true),
+        })
+        {
+            var path = Path.Combine(_dir, $"combo-{trace}-{port}-{wait}-{gate}.json".Replace("\\", "_"));
+            var model = TelemetryFile.Load(path);
+            if (trace != null) model.SetTrace(trace);
+            if (port.HasValue) model.SetLive(port.Value, wait);
+            if (gate) model.Set("Gauges", true);
+            model.Save();
+
+            var text = File.ReadAllText(path);
+            Assert.DoesNotThrow(
+                () => JsonDocument.Parse(text, new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = false }),
+                $"invalid JSON for trace={trace}, port={port}, wait={wait}, gate={gate}:\n{text}");
+        }
+    }
+}

--- a/test/Typhon.Shell.Tests/Typhon.Shell.Tests.csproj
+++ b/test/Typhon.Shell.Tests/Typhon.Shell.Tests.csproj
@@ -12,6 +12,9 @@
         <PackageReference Include="NUnit" Version="4.6.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+        <!-- So a test can read a file `typhon telemetry` wrote through the SAME loader the engine uses, rather than
+             through our own parser. A config tool that writes a shape only it can read is worse than no tool. -->
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Typhon.Workbench.Tests/CaptureApiTests.cs
+++ b/test/Typhon.Workbench.Tests/CaptureApiTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Typhon.Workbench.Dtos.Profiler;
+using Typhon.Workbench.Dtos.Sessions;
+using Typhon.Workbench.Fixtures;
+
+namespace Typhon.Workbench.Tests;
+
+/// <summary>
+/// On-demand tick capture (#805) — the HTTP and SSE surface. Covers AC-11 (the capture endpoint), AC-12 (the
+/// <c>captureStateChanged</c> SSE delta) and AC-13 (the attach-time mode choice).
+/// </summary>
+[TestFixture]
+public sealed class CaptureApiTests
+{
+    private WorkbenchFactory _factory;
+    private HttpClient _client;
+
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new WorkbenchFactory();
+        _client = _factory.CreateAuthenticatedClient();
+    }
+
+    [TearDown]
+    public void TearDown() => _factory.Dispose();
+
+    private async Task<(SessionDto Session, MockTcpProfilerServer Server)> AttachAsync(bool cherryPick)
+    {
+        var server = new MockTcpProfilerServer
+        {
+            BlockInterval = TimeSpan.FromMilliseconds(30),
+            MaxBlocks = 200,
+        };
+        server.Start();
+
+        var resp = await _client.PostAsJsonAsync(
+            "/api/sessions/attach",
+            new CreateAttachSessionRequest($"127.0.0.1:{server.Port}", CherryPick: cherryPick));
+        resp.EnsureSuccessStatusCode();
+        var session = JsonSerializer.Deserialize<SessionDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+        return (session, server);
+    }
+
+    private HttpRequestMessage Authorized(HttpMethod method, string url, Guid sessionId)
+    {
+        var req = new HttpRequestMessage(method, url);
+        req.Headers.Add("X-Session-Token", sessionId.ToString());
+        return req;
+    }
+
+    /// <summary>AC-13 — cherry-pick starts idle; capture-everything preserves the pre-#805 behaviour.</summary>
+    [Test]
+    public async Task AttachMode_DeterminesInitialCaptureState()
+    {
+        var (cherry, cherryServer) = await AttachAsync(cherryPick: true);
+        await using (cherryServer)
+        {
+            var req = Authorized(HttpMethod.Get, $"/api/sessions/{cherry.SessionId}/profiler/capture", cherry.SessionId);
+            using var resp = await _client.SendAsync(req);
+            resp.EnsureSuccessStatusCode();
+            var state = JsonSerializer.Deserialize<CaptureStateDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.State, Is.EqualTo("Idle"), "cherry-pick attaches idle");
+                Assert.That(state.Mode, Is.EqualTo("CherryPick"));
+            });
+        }
+
+        var (everything, everythingServer) = await AttachAsync(cherryPick: false);
+        await using (everythingServer)
+        {
+            var req = Authorized(HttpMethod.Get, $"/api/sessions/{everything.SessionId}/profiler/capture", everything.SessionId);
+            using var resp = await _client.SendAsync(req);
+            resp.EnsureSuccessStatusCode();
+            var state = JsonSerializer.Deserialize<CaptureStateDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.State, Is.EqualTo("Everything"), "the default must remain today's always-on behaviour");
+                Assert.That(state.Mode, Is.EqualTo("Everything"));
+            });
+        }
+    }
+
+    /// <summary>AC-11 — arming through the endpoint moves the session into Recording with the requested budget.</summary>
+    [Test]
+    public async Task PostCapture_ArmsAWindow_AndReportsRemaining()
+    {
+        var (session, server) = await AttachAsync(cherryPick: true);
+        await using var _ = server;
+
+        var req = Authorized(HttpMethod.Post, $"/api/sessions/{session.SessionId}/profiler/capture", session.SessionId);
+        req.Content = JsonContent.Create(new CaptureRequest(25));
+        using var resp = await _client.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+
+        var state = JsonSerializer.Deserialize<CaptureStateDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.State, Is.EqualTo("Recording"), "the click must be acknowledged immediately, not one tick later");
+            Assert.That(state.Remaining, Is.EqualTo(25));
+        });
+    }
+
+    /// <summary>
+    /// AC-11 — arming a capture-everything session is a conflict, not a silent mode switch. Allowing it would leave the
+    /// session reporting a bounded window while its mode still said "everything": a state nobody asked for and the UI
+    /// has no way to describe.
+    /// </summary>
+    [Test]
+    public async Task PostCapture_OnCaptureEverythingSession_Is409()
+    {
+        var (session, server) = await AttachAsync(cherryPick: false);
+        await using var _ = server;
+
+        var req = Authorized(HttpMethod.Post, $"/api/sessions/{session.SessionId}/profiler/capture", session.SessionId);
+        req.Content = JsonContent.Create(new CaptureRequest(10));
+        using var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+    }
+
+    /// <summary>AC-11 — a negative budget is a client error, not a silently-clamped one.</summary>
+    [Test]
+    public async Task PostCapture_RejectsNegativeTickCount()
+    {
+        var (session, server) = await AttachAsync(cherryPick: true);
+        await using var _ = server;
+
+        var req = Authorized(HttpMethod.Post, $"/api/sessions/{session.SessionId}/profiler/capture", session.SessionId);
+        req.Content = JsonContent.Create(new CaptureRequest(-5));
+        using var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    /// <summary>AC-11 — the endpoint is gated by the bootstrap token like every sibling under <c>/api/sessions</c>.</summary>
+    [Test]
+    public async Task PostCapture_WithoutBootstrapToken_Is401()
+    {
+        var (session, server) = await AttachAsync(cherryPick: true);
+        await using var _ = server;
+
+        using var unauthenticated = _factory.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/api/sessions/{session.SessionId}/profiler/capture");
+        req.Headers.Add("X-Session-Token", session.SessionId.ToString());
+        req.Content = JsonContent.Create(new CaptureRequest(10));
+        using var resp = await unauthenticated.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+    }
+
+    /// <summary>
+    /// AC-12 — a subscriber sees the capture state on connect and again when a window is armed. The connect-time frame
+    /// matters as much as the delta: without it, a client subscribing mid-window would render "not recording" for the
+    /// whole capture.
+    /// </summary>
+    [Test]
+    public async Task Stream_EmitsCaptureStateOnConnect_AndOnArm()
+    {
+        var (session, server) = await AttachAsync(cherryPick: true);
+        await using var _ = server;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var streamReq = Authorized(HttpMethod.Get, $"/api/sessions/{session.SessionId}/profiler/stream", session.SessionId);
+        using var resp = await _client.SendAsync(streamReq, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        using var stream = await resp.Content.ReadAsStreamAsync(cts.Token);
+        using var reader = new StreamReader(stream);
+
+        string firstCaptureJson = null;
+        while (firstCaptureJson is null)
+        {
+            var frame = await Fixtures.SseFrameReader.ReadFrameAsync(reader, cts.Token);
+            if (frame is null) break;
+            if (frame.Value.EventType == "captureStateChanged")
+            {
+                firstCaptureJson = frame.Value.Data;
+            }
+        }
+        Assert.That(firstCaptureJson, Is.Not.Null, "the stream must seed capture state on connect");
+        using (var doc = JsonDocument.Parse(firstCaptureJson!))
+        {
+            Assert.That(doc.RootElement.GetProperty("captureState").GetProperty("state").GetString(),
+                Is.EqualTo("Idle"), "a cherry-pick session starts idle");
+        }
+
+        // Arm, then expect a fresh delta reporting Recording.
+        var armReq = Authorized(HttpMethod.Post, $"/api/sessions/{session.SessionId}/profiler/capture", session.SessionId);
+        armReq.Content = JsonContent.Create(new CaptureRequest(50));
+        (await _client.SendAsync(armReq, cts.Token)).EnsureSuccessStatusCode();
+
+        var sawRecording = false;
+        while (!sawRecording)
+        {
+            var frame = await Fixtures.SseFrameReader.ReadFrameAsync(reader, cts.Token);
+            if (frame is null) break;
+            if (frame.Value.EventType != "captureStateChanged") continue;
+            using var doc = JsonDocument.Parse(frame.Value.Data);
+            if (doc.RootElement.GetProperty("captureState").GetProperty("state").GetString() == "Recording")
+            {
+                sawRecording = true;
+            }
+        }
+        Assert.That(sawRecording, Is.True, "arming must fan out a captureStateChanged delta to SSE subscribers");
+    }
+}

--- a/test/Typhon.Workbench.Tests/Fixtures/MockRecordFactoryTests.cs
+++ b/test/Typhon.Workbench.Tests/Fixtures/MockRecordFactoryTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Typhon.Profiler;
+using Typhon.Workbench.Fixtures;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Fixtures;
+
+/// <summary>
+/// Validates <see cref="MockRecordFactory"/> against the real <see cref="IncrementalCacheBuilder"/> — the consumer the
+/// on-demand-capture filter (#805) sits in front of.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are deliberately <b>fact-finding</b> tests, not just fixture smoke tests. The #805 design asserts two claims
+/// about builder behaviour that the whole filter design rests on, and neither is obvious from reading a record layout:
+/// </para>
+/// <list type="number">
+///   <item><b>The 241 nudge is real.</b> A tick finalized <i>with</i> <c>SchedulerMetronomeWait</c> reports a longer
+///   <c>DurationUs</c> than the same tick finalized without it, because the builder lets 241's timestamp push
+///   <c>_currentTickLastTs</c> past <c>TickEnd</c> before sealing. If that were false, exempting 241 would be
+///   cargo-cult and the design's duration-parity argument would be wrong.</item>
+///   <item><b><c>PerTickSnapshot</c> carries an absolute tick number</b> that survives the wire, which is the only
+///   source of true simulation tick numbers available to a live attach session.</item>
+/// </list>
+/// <para>
+/// Proving them here, against the production builder, is what lets the filter tests downstream assert on behaviour
+/// instead of on assumptions.
+/// </para>
+/// </remarks>
+[TestFixture]
+public sealed class MockRecordFactoryTests
+{
+    private const long TicksPerUs = 10;              // matches the mock Init header's 10 MHz TimestampFrequency
+    private static readonly ProfilerHeader Header = new() { Version = TraceFileHeader.CurrentVersion, TimestampFrequency = 10_000_000 };
+
+    private static IncrementalCacheBuilder NewBuilder(out LiveCacheTempFile temp)
+    {
+        temp = LiveCacheTempFile.Create(Guid.NewGuid());
+        Span<byte> fingerprint = stackalloc byte[32];
+        return new IncrementalCacheBuilder(temp.Sink, ownsSink: false, Header, fingerprint,
+            new Dictionary<int, string>(), new Dictionary<ushort, string>());
+    }
+
+    /// <summary>Every factory record must survive the builder's walk — a bad size prefix makes it bail silently mid-buffer.</summary>
+    [Test]
+    public void EveryFactoryRecord_ParsesThroughTheBuilderWalk()
+    {
+        var records = MockRecordFactory.Concat(
+            MockRecordFactory.TickStart(1000),
+            MockRecordFactory.ThreadInfo(1000, threadSlot: 0, managedThreadId: 7, name: "Worker0"),
+            MockRecordFactory.SchedulerChunk(1010, durationTicks: 30, systemIndex: 3),
+            MockRecordFactory.GenericSpan(TraceEventKind.RuntimeTransactionLifecycle, 1020, durationTicks: 10),
+            MockRecordFactory.TickEnd(1100),
+            MockRecordFactory.PerTickSnapshot(1105, engineTickNumber: 41),
+            MockRecordFactory.OverloadDetector(1106, tick: 41, consecutiveOverrun: 2, consecutiveUnderrun: 3),
+            MockRecordFactory.MetronomeWait(1200, durationTicks: 500));
+
+        // CountRecords mirrors the builder's own bail-out rules, so agreement with the literal count proves every
+        // size prefix is self-consistent and no record silently truncates the walk.
+        Assert.That(MockRecordFactory.CountRecords(records), Is.EqualTo(8), "all 8 records must be walkable");
+
+        var kinds = MockRecordFactory.KindsIn(records);
+        Assert.That(kinds, Is.EqualTo(new[]
+        {
+            TraceEventKind.TickStart,
+            TraceEventKind.ThreadInfo,
+            TraceEventKind.SchedulerChunk,
+            TraceEventKind.RuntimeTransactionLifecycle,
+            TraceEventKind.TickEnd,
+            TraceEventKind.PerTickSnapshot,
+            TraceEventKind.SchedulerOverloadDetector,
+            TraceEventKind.SchedulerMetronomeWait,
+        }), "kinds must round-trip in wire order");
+    }
+
+    /// <summary>
+    /// FACT #1 — the 241 nudge. Two identical ticks, one with a trailing <c>SchedulerMetronomeWait</c> and one without.
+    /// The builder must report a LONGER duration for the one that has it. This is the trap the design's exempt set exists
+    /// to avoid: filter 241 while idle and every idle bar shrinks relative to every armed bar.
+    /// </summary>
+    [Test]
+    public void MetronomeWait_ExtendsTickDuration_BeyondTickEnd()
+    {
+        const long tickStartTs = 1_000;
+        const long tickEndTs = 1_500;      // 500 ticks = 50 us
+        const long metronomeTs = 1_900;    // 900 ticks = 90 us from tick start
+
+        var withoutWait = FinalizeOneTick(
+            MockRecordFactory.TickStart(tickStartTs),
+            MockRecordFactory.TickEnd(tickEndTs));
+
+        var withWait = FinalizeOneTick(
+            MockRecordFactory.TickStart(tickStartTs),
+            MockRecordFactory.TickEnd(tickEndTs),
+            MockRecordFactory.MetronomeWait(metronomeTs, durationTicks: 200));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(withoutWait.DurationUs, Is.EqualTo((tickEndTs - tickStartTs) / (double)TicksPerUs).Within(0.01),
+                "without 241 the tick ends at TickEnd");
+            Assert.That(withWait.DurationUs, Is.EqualTo((metronomeTs - tickStartTs) / (double)TicksPerUs).Within(0.01),
+                "with 241 the tick extends to the metronome wait start");
+        });
+
+        Assert.That(withWait.DurationUs, Is.GreaterThan(withoutWait.DurationUs),
+            "241 must extend the tick — if this ever fails, the design's duration-parity argument for exempting 241 is void");
+    }
+
+    /// <summary>
+    /// FACT #2 — <c>PerTickSnapshot</c> carries an absolute tick number that survives the wire. This is the sole source
+    /// of true simulation tick numbers for a live attach session (the common header has none, and TickStart has no
+    /// payload at all), so #805's numbering offset depends on it being readable at wire offset 12.
+    /// </summary>
+    [Test]
+    public void PerTickSnapshot_CarriesAbsoluteTickNumber_AtWireOffset12()
+    {
+        const uint engineTick = 216_000;
+        var record = MockRecordFactory.PerTickSnapshot(timestamp: 5_000, engineTickNumber: engineTick);
+
+        var decoded = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(record.AsSpan(12));
+        Assert.That(decoded, Is.EqualTo(engineTick), "the absolute tick number must sit at offset 12 of the record");
+
+        // And it must survive a real round-trip through the production codec, not just our own write.
+        var data = PerTickSnapshotEventCodec.DecodePerTickSnapshot(record);
+        Assert.That(data.TickNumber, Is.EqualTo(engineTick), "the production decoder must read back the same value");
+    }
+
+    /// <summary>Detail records must actually register as events, otherwise "EventCount == 0 when idle" proves nothing.</summary>
+    [Test]
+    public void DetailRecords_IncrementTickEventCount()
+    {
+        var bare = FinalizeOneTick(
+            MockRecordFactory.TickStart(1_000),
+            MockRecordFactory.TickEnd(1_500));
+
+        var withDetail = FinalizeOneTick(
+            MockRecordFactory.TickStart(1_000),
+            MockRecordFactory.SchedulerChunk(1_100, durationTicks: 50, systemIndex: 2),
+            MockRecordFactory.SchedulerChunk(1_200, durationTicks: 50, systemIndex: 3),
+            MockRecordFactory.TickEnd(1_500));
+
+        Assert.That(withDetail.EventCount, Is.GreaterThan(bare.EventCount),
+            "SchedulerChunk records must count as events so an idle tick's EventCount is meaningfully zero-ish");
+        Assert.That(withDetail.ActiveSystemsBitmask, Is.Not.EqualTo(0UL),
+            "SchedulerChunk must register its system index — proves the span payload offset is correct");
+    }
+
+    /// <summary>
+    /// Feeds one tick's records plus a following <c>TickStart</c> (the builder finalizes tick N only when it sees
+    /// TickStart of N+1) and returns the resulting summary.
+    /// </summary>
+    private static TickSummary FinalizeOneTick(params byte[][] tickRecords)
+    {
+        LiveCacheTempFile temp = null;
+        try
+        {
+            var builder = NewBuilder(out temp);
+            try
+            {
+                builder.FeedRawRecords(MockRecordFactory.Concat(tickRecords));
+                builder.FeedRawRecords(MockRecordFactory.TickStart(9_000_000));
+                Assert.That(builder.TickSummaries, Is.Not.Empty, "a tick must have been finalized");
+                return builder.TickSummaries.Last();
+            }
+            finally
+            {
+                builder.Dispose();
+            }
+        }
+        finally
+        {
+            temp?.Dispose();
+        }
+    }
+}

--- a/test/Typhon.Workbench.Tests/Fixtures/MockTcpProfilerServerTests.cs
+++ b/test/Typhon.Workbench.Tests/Fixtures/MockTcpProfilerServerTests.cs
@@ -69,4 +69,74 @@ public sealed class MockTcpProfilerServerTests
             await stream.ReadExactlyAsync(blockPayload, cts.Token);
         }
     }
+
+    /// <summary>
+    /// Scripted mode: no automatic emission, the test owns the stream. Proves <see cref="MockTcpProfilerServer.SendBlockAsync"/>
+    /// frames a caller-built record buffer correctly and that block boundaries are the caller's to choose — which is what
+    /// makes a "block straddling the arm boundary" test possible at all.
+    /// </summary>
+    [Test]
+    public async Task Scripted_EmitsNothingUntilDriven_ThenHonoursCallerBlockBoundaries()
+    {
+        await using var server = new MockTcpProfilerServer { Scripted = true };
+        server.Start();
+
+        using var client = new TcpClient();
+        await client.ConnectAsync("127.0.0.1", server.Port);
+        var stream = client.GetStream();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Init arrives on connect.
+        var header = new byte[LiveStreamProtocol.FrameHeaderSize];
+        await stream.ReadExactlyAsync(header, cts.Token);
+        var (initType, initLen) = LiveStreamProtocol.ReadFrameHeader(header);
+        Assert.That(initType, Is.EqualTo(LiveFrameType.Init));
+        await stream.ReadExactlyAsync(new byte[initLen], cts.Token);
+
+        await server.WaitForClientAsync(cts.Token);
+        Assert.That(client.Available, Is.Zero, "scripted mode must not emit blocks on its own");
+
+        // Two caller-chosen blocks: the tick is deliberately split across them.
+        await server.SendBlockAsync(MockRecordFactory.Concat(
+            MockRecordFactory.TickStart(1_000),
+            MockRecordFactory.SchedulerChunk(1_050, durationTicks: 10)), cts.Token);
+        await server.SendBlockAsync(MockRecordFactory.TickEnd(1_500), cts.Token);
+
+        for (var i = 0; i < 2; i++)
+        {
+            await stream.ReadExactlyAsync(header, cts.Token);
+            var (blockType, blockLen) = LiveStreamProtocol.ReadFrameHeader(header);
+            Assert.That(blockType, Is.EqualTo(LiveFrameType.Block), $"frame {i} must be a Block");
+            await stream.ReadExactlyAsync(new byte[blockLen], cts.Token);
+        }
+    }
+
+    /// <summary>
+    /// Engine-restart simulation: dropping the client leaves the listener up so a reconnect lands a second connection
+    /// and a second Init — the shape <c>AttachSessionRuntime</c>'s reconnect loop sees when an app is killed and relaunched.
+    /// </summary>
+    [Test]
+    public async Task DropClient_LeavesListenerUp_SoAReconnectGetsAFreshInit()
+    {
+        await using var server = new MockTcpProfilerServer { Scripted = true };
+        server.Start();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        using (var first = new TcpClient())
+        {
+            await first.ConnectAsync("127.0.0.1", server.Port);
+            await server.WaitForClientAsync(cts.Token);
+        }
+        await server.DropClientAsync();
+
+        using var second = new TcpClient();
+        await second.ConnectAsync("127.0.0.1", server.Port);
+        await server.WaitForClientAsync(cts.Token);
+
+        var header = new byte[LiveStreamProtocol.FrameHeaderSize];
+        await second.GetStream().ReadExactlyAsync(header, cts.Token);
+        var (type, _) = LiveStreamProtocol.ReadFrameHeader(header);
+        Assert.That(type, Is.EqualTo(LiveFrameType.Init), "the reconnect must receive a fresh Init frame");
+        Assert.That(server.ConnectionCount, Is.EqualTo(2), "both connections must have been accepted");
+    }
 }

--- a/test/Typhon.Workbench.Tests/Sessions/CaptureArmingTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/CaptureArmingTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Typhon.Workbench.Dtos.Profiler;
+using Typhon.Workbench.Fixtures;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// On-demand tick capture (#805) — arming semantics. Covers AC-4 (exactly N ticks), AC-5 (arming mid-tick does not
+/// retro-arm the tick in flight), AC-6 (a block straddling the arm boundary is filtered per record) and AC-7 (two
+/// windows in one session, with true contiguous tick numbering across the idle gap).
+/// </summary>
+[TestFixture]
+public sealed class CaptureArmingTests
+{
+    private static CancellationToken Timeout10s => new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+
+    /// <summary>A tick carries recorded detail iff a SchedulerChunk reached the builder for it.</summary>
+    private static bool HasDetail(TickSummaryDto s) => s.ActiveSystemsBitmask != "0";
+
+    /// <summary>AC-4 — <c>Arm(N)</c> records exactly N consecutive ticks, then stops on its own.</summary>
+    [Test]
+    public async Task ArmN_RecordsExactlyNConsecutiveTicks_ThenStops()
+    {
+        const int windowTicks = 3;
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        // Two idle ticks first, so the window is provably bounded on both sides.
+        await h.SendTickAsync(0, engineTick: 1, detailRecords: 4, ct: Timeout10s);
+        await h.SendTickAsync(1, engineTick: 2, detailRecords: 4, ct: Timeout10s);
+        await h.WaitForSummariesAsync(1);
+
+        h.Runtime.Arm(windowTicks);
+
+        for (var i = 2; i < 10; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(i + 1), detailRecords: 4, ct: Timeout10s);
+        }
+        await h.WaitForSummariesAsync(9);
+
+        var summaries = h.Summaries;
+        var recorded = summaries.Where(HasDetail).Select(s => s.TickNumber).ToArray();
+
+        Assert.That(recorded, Has.Length.EqualTo(windowTicks),
+            $"exactly {windowTicks} ticks must carry detail; got [{string.Join(", ", recorded)}]");
+
+        // ...and they must be consecutive.
+        for (var i = 1; i < recorded.Length; i++)
+        {
+            Assert.That(recorded[i] - recorded[i - 1], Is.EqualTo(1u), "the recorded window must be contiguous");
+        }
+
+        Assert.That(h.Runtime.CaptureState.State, Is.EqualTo("Idle"), "the session must fall back to idle once the window closes");
+        Assert.That(h.Runtime.CaptureState.RecordedTicks, Is.EqualTo(windowTicks), "exactly the window's ticks count as recorded");
+    }
+
+    /// <summary>
+    /// AC-5 — arming while a tick is already in flight must not retro-arm it. The window opens at the NEXT
+    /// <c>TickStart</c>, so a capture can never contain a partial tick.
+    /// </summary>
+    [Test]
+    public async Task ArmingMidTick_LeavesTheTickInFlightUntouched()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        // Open tick 1 and deliver some of its detail, but do not close it.
+        await h.SendBlockAsync(MockRecordFactory.Concat(
+            MockRecordFactory.TickStart(CaptureHarness.At(0)),
+            MockRecordFactory.SchedulerChunk(CaptureHarness.At(100), durationTicks: 50, systemIndex: 1)), Timeout10s);
+
+        // Arm mid-tick. Tick 1 is already open and must stay idle.
+        h.Runtime.Arm(1);
+
+        // Close tick 1, then run tick 2 (which is the one that should be armed) and tick 3 to finalize it.
+        await h.SendBlockAsync(MockRecordFactory.Concat(
+            MockRecordFactory.SchedulerChunk(CaptureHarness.At(200), durationTicks: 50, systemIndex: 2),
+            MockRecordFactory.TickEnd(CaptureHarness.At(5_000)),
+            MockRecordFactory.MetronomeWait(CaptureHarness.At(9_000), durationTicks: 200)), Timeout10s);
+        await h.SendTickAsync(1, engineTick: 2, detailRecords: 4, ct: Timeout10s);
+        await h.SendTickAsync(2, engineTick: 3, detailRecords: 4, ct: Timeout10s);
+        await h.WaitForSummariesAsync(2);
+
+        var summaries = h.Summaries;
+        var first = summaries.First();
+        Assert.That(HasDetail(first), Is.False,
+            "the tick already in flight when Arm() was called must NOT be recorded — a window may not contain a partial tick");
+
+        var recorded = summaries.Where(HasDetail).ToArray();
+        Assert.That(recorded, Has.Length.EqualTo(1), "exactly the one tick after the arm must be recorded");
+        Assert.That(recorded[0].TickNumber, Is.EqualTo(first.TickNumber + 1), "the window must open on the very next tick");
+    }
+
+    /// <summary>
+    /// AC-6 — a single Block frame that straddles the arm boundary must be filtered <b>per record</b>. Block frames are
+    /// a timestamp-ordered merge across all thread slots on a 1 ms drain cadence, so they do not align to ticks;
+    /// dropping or passing one wholesale would leak pre-arm detail or lose post-arm detail.
+    /// </summary>
+    [Test]
+    public async Task BlockStraddlingTheArmBoundary_IsFilteredPerRecord()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        // Open tick 1 (idle).
+        await h.SendBlockAsync(MockRecordFactory.Concat(
+            MockRecordFactory.TickStart(CaptureHarness.At(0)),
+            MockRecordFactory.SchedulerChunk(CaptureHarness.At(100), durationTicks: 50, systemIndex: 1)), Timeout10s);
+
+        h.Runtime.Arm(1);
+
+        // ONE block carrying the tail of idle tick 1 AND the whole of armed tick 2. The arm decision happens in the
+        // middle of this buffer.
+        await h.SendBlockAsync(MockRecordFactory.Concat(
+            MockRecordFactory.SchedulerChunk(CaptureHarness.At(200), durationTicks: 50, systemIndex: 2),   // still tick 1 — must be dropped
+            MockRecordFactory.TickEnd(CaptureHarness.At(5_000)),
+            MockRecordFactory.MetronomeWait(CaptureHarness.At(9_000), durationTicks: 200),
+            MockRecordFactory.TickStart(CaptureHarness.At(10_000)),                                        // tick 2 opens — arm takes effect
+            MockRecordFactory.SchedulerChunk(CaptureHarness.At(10_100), durationTicks: 50, systemIndex: 5), // must be kept
+            MockRecordFactory.SchedulerChunk(CaptureHarness.At(10_200), durationTicks: 50, systemIndex: 6), // must be kept
+            MockRecordFactory.TickEnd(CaptureHarness.At(15_000)),
+            MockRecordFactory.MetronomeWait(CaptureHarness.At(19_000), durationTicks: 200)), Timeout10s);
+
+        // Tick 3 finalizes tick 2.
+        await h.SendTickAsync(2, engineTick: 3, detailRecords: 0, ct: Timeout10s);
+        await h.WaitForSummariesAsync(2);
+
+        var summaries = h.Summaries;
+        Assert.That(summaries, Has.Count.GreaterThanOrEqualTo(2));
+        Assert.Multiple(() =>
+        {
+            Assert.That(HasDetail(summaries[0]), Is.False, "the idle tick's detail, carried in the same block, must be dropped");
+            Assert.That(HasDetail(summaries[1]), Is.True, "the armed tick's detail, carried in the same block, must be kept");
+        });
+    }
+
+    /// <summary>
+    /// AC-7 — two windows in one session both survive, and tick numbering stays contiguous and monotonic across the
+    /// idle gap between them. This is the property the whole exempt-spine decision exists to protect: the builder
+    /// derives tick numbers by counting <c>TickStart</c> markers, so a gap in the spine would renumber everything after it.
+    /// </summary>
+    [Test]
+    public async Task TwoWindows_BothRecorded_WithContiguousTickNumbersAcrossTheGap()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        var tickIndex = 0;
+        async Task RunTicks(int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                await h.SendTickAsync(tickIndex, engineTick: (uint)(tickIndex + 1), detailRecords: 3, ct: Timeout10s);
+                tickIndex++;
+            }
+        }
+
+        await RunTicks(2);                       // idle
+        h.Runtime.Arm(2);
+        await RunTicks(2);                       // window 1
+        await RunTicks(3);                       // idle gap
+        h.Runtime.Arm(2);
+        await RunTicks(2);                       // window 2
+        await RunTicks(2);                       // idle tail (also finalizes window 2)
+        await h.WaitForSummariesAsync(10);
+
+        var summaries = h.Summaries;
+        var numbers = summaries.Select(s => s.TickNumber).ToArray();
+
+        // Contiguity is the headline assertion: no renumbering, no gaps, no repeats.
+        for (var i = 1; i < numbers.Length; i++)
+        {
+            Assert.That(numbers[i], Is.EqualTo(numbers[i - 1] + 1),
+                $"tick numbers must be contiguous across idle gaps; got [{string.Join(", ", numbers)}]");
+        }
+
+        var recorded = summaries.Where(HasDetail).Select(s => s.TickNumber).ToArray();
+        Assert.That(recorded, Has.Length.EqualTo(4), $"both windows must be recorded; got [{string.Join(", ", recorded)}]");
+
+        // Two runs of two, separated by an idle gap — not one run of four.
+        var runs = new List<List<uint>>();
+        foreach (var n in recorded)
+        {
+            if (runs.Count == 0 || n != runs[^1][^1] + 1)
+            {
+                runs.Add([n]);
+            }
+            else
+            {
+                runs[^1].Add(n);
+            }
+        }
+        Assert.That(runs, Has.Count.EqualTo(2), $"the two windows must be separated by idle ticks; runs were [{string.Join(" | ", runs.Select(r => string.Join(",", r)))}]");
+        Assert.That(runs[0], Has.Count.EqualTo(2));
+        Assert.That(runs[1], Has.Count.EqualTo(2));
+        Assert.That(h.Runtime.CaptureState.RecordedTicks, Is.EqualTo(4), "both windows count toward the recorded total");
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/CaptureFilterTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/CaptureFilterTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Typhon.Profiler;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// On-demand tick capture (#805) — the record filter in <c>AttachSessionRuntime.HandleBlock</c>.
+/// Covers AC-1 (exempt set), AC-2 (summary fidelity while idle) and AC-3 (duration parity).
+/// </summary>
+[TestFixture]
+public sealed class CaptureFilterTests
+{
+    private static CancellationToken Timeout10s => new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+
+    /// <summary>
+    /// AC-1 — while idle, detail records are dropped and the exempt per-tick skeleton is retained. Asserted through the
+    /// byte counters the filter maintains: retained must be strictly less than received, and the surviving ticks must
+    /// still be finalized (which can only happen if the spine got through).
+    /// </summary>
+    [Test]
+    public async Task Idle_DropsDetailRecords_ButKeepsTheTickSpine()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        for (var i = 0; i < 4; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(i + 1), detailRecords: 20, ct: Timeout10s);
+        }
+        await h.WaitForSummariesAsync(3);
+
+        var state = h.Runtime.CaptureState;
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.State, Is.EqualTo("Idle"), "cherry-pick mode starts idle");
+            Assert.That(state.BytesReceived, Is.GreaterThan(0), "the engine's bytes must have been counted");
+            Assert.That(state.BytesRetained, Is.LessThan(state.BytesReceived), "detail records must have been dropped");
+            Assert.That(state.RecordedTicks, Is.Zero, "no window was armed, so nothing was recorded");
+        });
+
+        // The spine survived: ticks were finalized at all, and each carries ONLY the exempt skeleton.
+        // Note EventCount does not go to zero — the builder counts every record it is fed, and the five exempt records
+        // per tick genuinely are in the chunk. What must be gone is the 20 detail records.
+        Assert.That(h.Summaries, Is.Not.Empty, "ticks must still be finalized while idle — the spine is exempt");
+        Assert.That(h.Summaries.All(s => s.EventCount == CaptureHarness.ExemptRecordsPerTick), Is.True,
+            $"idle ticks must carry exactly the {CaptureHarness.ExemptRecordsPerTick} exempt records and none of the 20 detail records; "
+            + $"got [{string.Join(", ", h.Summaries.Select(s => s.EventCount))}]");
+        Assert.That(h.Summaries.All(s => s.ActiveSystemsBitmask == "0"), Is.True,
+            "no SchedulerChunk may have reached the builder while idle");
+    }
+
+    /// <summary>
+    /// AC-1 (direct) — the exempt set is exactly the six kinds the design names. Asserted against the filter's own
+    /// predicate rather than through the pipeline, so a kind added or removed by accident fails loudly here.
+    /// </summary>
+    [Test]
+    public void ExemptSet_IsExactlyTheSixPerTickKinds()
+    {
+        var expected = new[]
+        {
+            TraceEventKind.TickStart,
+            TraceEventKind.TickEnd,
+            TraceEventKind.PerTickSnapshot,
+            TraceEventKind.ThreadInfo,
+            TraceEventKind.SchedulerMetronomeWait,
+            TraceEventKind.SchedulerOverloadDetector,
+        };
+
+        foreach (var kind in expected)
+        {
+            Assert.That(AttachSessionRuntime.IsExemptKind(kind), Is.True, $"{kind} must be exempt");
+        }
+
+        // QueueTickEnd is the deliberate exclusion: one record per (tick x active queue), scales with queue count,
+        // and is not a TickSummary input.
+        Assert.That(AttachSessionRuntime.IsExemptKind(TraceEventKind.QueueTickEnd), Is.False,
+            "QueueTickEnd must NOT be exempt — it scales with queue count");
+        Assert.That(AttachSessionRuntime.IsExemptKind(TraceEventKind.SchedulerChunk), Is.False,
+            "SchedulerChunk is the canonical filterable detail record");
+
+        var exemptCount = Enumerable.Range(0, 256)
+            .Count(i => AttachSessionRuntime.IsExemptKind((TraceEventKind)i));
+        Assert.That(exemptCount, Is.EqualTo(expected.Length), "the exempt set must contain exactly the six named kinds");
+    }
+
+    /// <summary>
+    /// AC-2 — an idle tick's summary still carries everything the timeline draws: true-shaped tick numbers, start,
+    /// duration, overload level, multiplier and the metronome wait. Only the detail-derived fields go empty.
+    /// </summary>
+    [Test]
+    public async Task Idle_TickSummary_RetainsEveryFieldExceptDetailDerivedOnes()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        for (var i = 0; i < 4; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(i + 1), detailRecords: 10, ct: Timeout10s);
+        }
+        await h.WaitForSummariesAsync(3);
+
+        var summaries = h.Summaries;
+        // Tick numbers must be contiguous — the spine guarantees no renumbering.
+        var numbers = summaries.Select(s => s.TickNumber).ToArray();
+        Assert.That(numbers, Is.EqualTo(numbers.OrderBy(n => n).ToArray()), "tick numbers must be monotonic");
+        for (var i = 1; i < numbers.Length; i++)
+        {
+            Assert.That(numbers[i] - numbers[i - 1], Is.EqualTo(1u), "tick numbers must be contiguous while idle");
+        }
+
+        // The metronome wait describes the gap PRECEDING a tick, so the first tick of a session legitimately has none.
+        // Skipping it here is not tolerance for a flaky field — it is the field's definition.
+        foreach (var s in summaries.Skip(1))
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(s.DurationUs, Is.GreaterThan(0), "an idle tick still has a real duration");
+                Assert.That(s.TickMultiplier, Is.EqualTo(1), "TickEnd payload must survive the filter");
+                Assert.That(s.MetronomeWaitUs, Is.GreaterThan(0), "SchedulerMetronomeWait must survive the filter");
+                Assert.That(s.ConsecutiveUnderrun, Is.EqualTo(2), "SchedulerOverloadDetector payload must survive the filter");
+                Assert.That(s.EventCount, Is.EqualTo(CaptureHarness.ExemptRecordsPerTick),
+                    "only the exempt skeleton may reach the builder — the 10 detail records must be gone");
+                Assert.That(s.MaxSystemDurationUs, Is.Zero, "MaxSystemDuration is detail-derived, so it goes empty");
+                Assert.That(s.ActiveSystemsBitmask, Is.EqualTo("0"), "the active-systems bitmask is detail-derived");
+            });
+        }
+    }
+
+    /// <summary>
+    /// AC-3 — <b>duration parity</b>, the subtlest requirement in the design. An idle tick and an armed tick built from
+    /// identical timings must report the identical duration.
+    /// </summary>
+    /// <remarks>
+    /// This guards the <c>SchedulerMetronomeWait</c> trap. The builder lets 241's timestamp push the tick's end past
+    /// <c>TickEnd</c> before sealing, so filtering 241 would make every idle bar shorter than every armed bar by the
+    /// post-TickEnd setup time — a step at both window edges that reads to an operator as "the profiler slowed my app
+    /// down when I hit Record". <c>MockRecordFactoryTests.MetronomeWait_ExtendsTickDuration_BeyondTickEnd</c> proves the
+    /// nudge is real (50 µs vs 90 µs); this proves the filter does not reintroduce it.
+    /// </remarks>
+    [Test]
+    public async Task IdleAndArmedTicks_ReportIdenticalDurations()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        // Ticks 0-2 idle, ticks 3-5 armed, ticks 6-8 idle again. Every tick has identical timing.
+        await h.SendTickAsync(0, engineTick: 1, detailRecords: 5, ct: Timeout10s);
+        await h.SendTickAsync(1, engineTick: 2, detailRecords: 5, ct: Timeout10s);
+        await h.SendTickAsync(2, engineTick: 3, detailRecords: 5, ct: Timeout10s);
+        await h.WaitForSummariesAsync(2);
+
+        h.Runtime.Arm(3);
+        for (var i = 3; i < 9; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(i + 1), detailRecords: 5, ct: Timeout10s);
+        }
+        await h.WaitForSummariesAsync(8);
+
+        var summaries = h.Summaries;
+        // Armed vs idle is discriminated on a genuinely detail-derived field. EventCount cannot serve here: it counts
+        // the exempt skeleton too, so an idle tick reports a small non-zero number rather than zero.
+        var armed = summaries.Where(s => s.ActiveSystemsBitmask != "0").ToArray();
+        var idle = summaries.Where(s => s.ActiveSystemsBitmask == "0").ToArray();
+
+        Assert.That(armed, Is.Not.Empty, "some ticks must have been recorded");
+        Assert.That(idle, Is.Not.Empty, "some ticks must have stayed idle");
+
+        var armedDuration = armed[0].DurationUs;
+        foreach (var s in summaries)
+        {
+            Assert.That(s.DurationUs, Is.EqualTo(armedDuration).Within(0.01),
+                $"tick {s.TickNumber} (events={s.EventCount}) must report the same duration as an armed tick — "
+                + "a systematic difference is the 241 filtering bug the exempt set exists to prevent");
+        }
+
+        // And the expected absolute value: TickStart -> metronome-wait start, not TickStart -> TickEnd.
+        Assert.That(armedDuration, Is.EqualTo(CaptureHarness.TickSealTicks / (double)CaptureHarness.TicksPerUs).Within(0.01),
+            "the tick must extend to the metronome wait, matching an unfiltered session");
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/CaptureHarness.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/CaptureHarness.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Typhon.Profiler;
+using Typhon.Workbench.Dtos.Profiler;
+using Typhon.Workbench.Fixtures;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// Drives an <see cref="AttachSessionRuntime"/> against a scripted <see cref="MockTcpProfilerServer"/> and collects the
+/// tick summaries it produces. The harness for on-demand tick capture (#805).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>No sleeps.</b> Tick summaries are collected from the runtime's <c>TickSummaryAdded</c> event and awaited through a
+/// <see cref="TaskCompletionSource"/>, so tests synchronise on the thing they actually care about rather than on a
+/// guessed delay. A test that polls a timer here would be flaky on a loaded CI box and slow everywhere else.
+/// </para>
+/// <para>
+/// <b>Tick timing.</b> The mock Init header declares a 10 MHz timestamp frequency, so 10 stopwatch ticks = 1 µs. Ticks
+/// are laid out <see cref="TickSpacing"/> apart with a <see cref="TickBodyTicks"/>-long body, which keeps the arithmetic
+/// in the assertions readable.
+/// </para>
+/// </remarks>
+internal sealed class CaptureHarness : IAsyncDisposable
+{
+    /// <summary>Stopwatch ticks per microsecond, given the mock Init header's 10 MHz frequency.</summary>
+    public const long TicksPerUs = 10;
+
+    /// <summary>Stopwatch ticks between consecutive tick starts.</summary>
+    public const long TickSpacing = 10_000;
+
+    /// <summary>
+    /// Timestamp the first synthesized tick starts at. Must be strictly positive.
+    /// </summary>
+    /// <remarks>
+    /// <c>IncrementalCacheBuilder.FinalizeCurrentTick</c> opens with <c>if (_currentTickFirstTs &lt;= 0) return;</c>, so a
+    /// tick whose <c>TickStart</c> carries timestamp 0 is silently discarded and never becomes a <c>TickSummary</c>. A
+    /// real engine cannot hit this — <c>Stopwatch.GetTimestamp()</c> is QPC since boot — but a fixture starting its
+    /// timeline at zero can, and the resulting off-by-one in the summary list is invisible until an assertion indexes
+    /// the wrong tick. Starting at a positive base removes the trap.
+    /// </remarks>
+    public const long TickTimeBase = 1_000_000;
+
+    /// <summary>A timestamp <paramref name="offset"/> stopwatch ticks into the synthesized timeline.</summary>
+    public static long At(long offset) => TickTimeBase + offset;
+
+    /// <summary>Stopwatch ticks from TickStart to TickEnd.</summary>
+    public const long TickBodyTicks = 5_000;
+
+    /// <summary>Stopwatch ticks from TickStart to the metronome-wait record that seals the tick.</summary>
+    public const long TickSealTicks = 9_000;
+
+    /// <summary>
+    /// Exempt records <see cref="BuildTick"/> emits per tick with gauges and seal enabled: <c>TickStart</c>,
+    /// <c>TickEnd</c>, <c>PerTickSnapshot</c>, <c>SchedulerOverloadDetector</c>, <c>SchedulerMetronomeWait</c>.
+    /// </summary>
+    /// <remarks>
+    /// An idle tick's <c>EventCount</c> settles on exactly this number, not zero: the builder counts every record it is
+    /// fed, and the exempt skeleton is genuinely present in the chunk. Measured, not assumed — see
+    /// <c>CaptureFilterTests.Idle_DropsDetailRecords_ButKeepsTheTickSpine</c>.
+    /// </remarks>
+    public const int ExemptRecordsPerTick = 5;
+
+    private readonly List<TickSummaryDto> _summaries = [];
+    private readonly object _gate = new();
+    private TaskCompletionSource _summaryArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public MockTcpProfilerServer Server { get; private init; }
+
+    public AttachSessionRuntime Runtime { get; private init; }
+
+    public static async Task<CaptureHarness> StartAsync(CaptureMode mode, CancellationToken ct = default)
+    {
+        var server = new MockTcpProfilerServer { Scripted = true };
+        server.Start();
+
+        var runtime = await AttachSessionRuntime.StartAsync(
+            Guid.NewGuid(), $"127.0.0.1:{server.Port}", NullLogger.Instance, ct, mode);
+
+        var harness = new CaptureHarness { Server = server, Runtime = runtime };
+        runtime.TickSummaryAdded += harness.OnTickSummary;
+        await server.WaitForClientAsync(ct);
+        return harness;
+    }
+
+    private void OnTickSummary(TickSummaryDto summary)
+    {
+        lock (_gate)
+        {
+            _summaries.Add(summary);
+            _summaryArrived.TrySetResult();
+            _summaryArrived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+
+    /// <summary>Snapshot of the tick summaries finalized so far.</summary>
+    public IReadOnlyList<TickSummaryDto> Summaries
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return [.. _summaries];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Send one tick's worth of records as a single Block frame.
+    /// </summary>
+    /// <param name="tickIndex">Zero-based index used to lay the tick out in time.</param>
+    /// <param name="engineTick">The absolute tick number the engine reports inside its gauge record.</param>
+    /// <param name="detailRecords">How many filterable detail records (SchedulerChunk) to include.</param>
+    /// <param name="includeGauges">Whether to emit the <c>PerTickSnapshot</c>. Off models an engine running without gauges.</param>
+    /// <param name="includeSeal">Whether to emit the trailing <c>SchedulerMetronomeWait</c> that extends the tick.</param>
+    public Task SendTickAsync(int tickIndex, uint engineTick, int detailRecords = 0, bool includeGauges = true, bool includeSeal = true,
+        CancellationToken ct = default)
+        => SendBlockAsync(BuildTick(tickIndex, engineTick, detailRecords, includeGauges, includeSeal), ct);
+
+    /// <summary>
+    /// Send one Block frame and return only once the runtime has actually consumed it.
+    /// </summary>
+    /// <remarks>
+    /// <b>This barrier is load-bearing, not defensive.</b> <see cref="MockTcpProfilerServer.SendBlockAsync"/> completes
+    /// when the bytes reach the socket, which says nothing about whether the read loop has processed them. Any test that
+    /// sends records and then calls <see cref="AttachSessionRuntime.Arm"/> is asserting on an ordering between the two,
+    /// so without this barrier the arm can land before or after the records it is meant to follow — and the test then
+    /// passes or fails on scheduler luck. Synchronising on the runtime's own received-bytes counter makes the ordering
+    /// exact.
+    /// </remarks>
+    public async Task SendBlockAsync(byte[] records, CancellationToken ct = default)
+    {
+        var before = Runtime.CaptureState.BytesReceived;
+        await Server.SendBlockAsync(records, ct);
+        var target = before + records.Length;
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (Runtime.CaptureState.BytesReceived < target)
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException(
+                    $"Runtime did not consume the block: expected {target} bytes received, saw {Runtime.CaptureState.BytesReceived}.");
+            }
+            await Task.Delay(2, ct);
+        }
+    }
+
+    /// <summary>Build one tick's records without sending them, so a test can choose its own block boundaries.</summary>
+    public static byte[] BuildTick(int tickIndex, uint engineTick, int detailRecords = 0, bool includeGauges = true, bool includeSeal = true)
+    {
+        var start = At(tickIndex * TickSpacing);
+        var parts = new List<byte[]> { MockRecordFactory.TickStart(start) };
+
+        for (var i = 0; i < detailRecords; i++)
+        {
+            parts.Add(MockRecordFactory.SchedulerChunk(start + 100 + i * 10, durationTicks: 50, systemIndex: (ushort)(i % 8)));
+        }
+
+        parts.Add(MockRecordFactory.TickEnd(start + TickBodyTicks, overloadLevel: 0, tickMultiplier: 1));
+        if (includeGauges)
+        {
+            parts.Add(MockRecordFactory.PerTickSnapshot(start + TickBodyTicks + 10, engineTick));
+        }
+        parts.Add(MockRecordFactory.OverloadDetector(start + TickBodyTicks + 20, tick: engineTick, consecutiveOverrun: 1, consecutiveUnderrun: 2));
+        if (includeSeal)
+        {
+            parts.Add(MockRecordFactory.MetronomeWait(start + TickSealTicks, durationTicks: 200));
+        }
+
+        return MockRecordFactory.Concat([.. parts]);
+    }
+
+    /// <summary>
+    /// Await until at least <paramref name="count"/> tick summaries have been finalized. Throws on timeout so a hung
+    /// expectation fails loudly instead of hanging the suite.
+    /// </summary>
+    public async Task WaitForSummariesAsync(int count, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(10));
+        while (true)
+        {
+            Task next;
+            lock (_gate)
+            {
+                if (_summaries.Count >= count)
+                {
+                    return;
+                }
+                next = _summaryArrived.Task;
+            }
+
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+            {
+                throw new TimeoutException($"Expected {count} tick summaries, saw {Summaries.Count} within the timeout.");
+            }
+            try
+            {
+                await next.WaitAsync(remaining);
+            }
+            catch (TimeoutException)
+            {
+                throw new TimeoutException($"Expected {count} tick summaries, saw {Summaries.Count} within the timeout.");
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Runtime.TickSummaryAdded -= OnTickSummary;
+        Runtime.Dispose();
+        await Server.DisposeAsync();
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/CaptureRestartTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/CaptureRestartTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Typhon.Workbench.Fixtures;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// On-demand tick capture (#805) — engine restart and auto-save. Covers AC-17 (a restart ends the session rather than
+/// silently continuing its tick axis), AC-18 (auto-save iff a window was recorded), AC-19 (flush ordering, so the last
+/// partial chunk survives) and AC-20 (retention over the captures directory).
+/// </summary>
+[TestFixture]
+public sealed class CaptureRestartTests
+{
+    private static CancellationToken Timeout15s => new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token;
+
+    private string _capturesDir;
+    private string _previousOverride;
+
+    /// <summary>
+    /// Redirect the captures directory into a temp folder for the whole fixture. Auto-save writes real files and then
+    /// runs a retention pass that DELETES files in that directory — pointing either at the developer's real capture
+    /// archive would make this fixture destructive.
+    /// </summary>
+    [SetUp]
+    public void RedirectCapturesDirectory()
+    {
+        _previousOverride = Environment.GetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable);
+        _capturesDir = Path.Combine(Path.GetTempPath(), "typhon-capture-restart-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_capturesDir);
+        Environment.SetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable, _capturesDir);
+    }
+
+    [TearDown]
+    public void RestoreCapturesDirectory()
+    {
+        Environment.SetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable, _previousOverride);
+        try { Directory.Delete(_capturesDir, recursive: true); } catch (IOException) { /* best-effort */ }
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+            await Task.Delay(10);
+        }
+        return condition();
+    }
+
+    /// <summary>
+    /// AC-17 — a genuine restart (a new engine process, so a new <c>CreatedUtcTicks</c>) ends the session. Continuing
+    /// would silently report run 2's tick 1 as tick N+1, because the builder's tick counter derives from counting
+    /// <c>TickStart</c> markers and never resets.
+    /// </summary>
+    [Test]
+    public async Task EngineRestart_EndsTheSession_RatherThanContinuingTheTickAxis()
+    {
+        await using var server = new MockTcpProfilerServer { Scripted = true, CreatedUtcTicks = 1_000 };
+        server.Start();
+        using var runtime = await AttachSessionRuntime.StartAsync(
+            Guid.NewGuid(), $"127.0.0.1:{server.Port}", NullLogger.Instance, Timeout15s, CaptureMode.CherryPick);
+
+        string shutdownReason = null;
+        runtime.ShutdownReceived += r => shutdownReason = r;
+        await server.WaitForClientAsync(Timeout15s);
+
+        // The app is relaunched: same binary (so the Init signature still matches) but a new process.
+        server.CreatedUtcTicks = 2_000;
+        await server.DropClientAsync();
+
+        var ended = await WaitUntilAsync(() => shutdownReason != null, TimeSpan.FromSeconds(12));
+        Assert.That(ended, Is.True, "a restart must terminate the session");
+        Assert.That(shutdownReason, Is.EqualTo("engine_restarted"),
+            "the reason must distinguish a restart from a signature mismatch, so the UI can offer a plain reconnect");
+    }
+
+    /// <summary>
+    /// AC-17 (the other half) — a transient socket drop within ONE engine process must NOT end the session. Ending it
+    /// on every reconnect would let a network hiccup destroy a capture, and the Init signature alone cannot tell the
+    /// two apart because it deliberately excludes <c>CreatedUtcTicks</c>.
+    /// </summary>
+    [Test]
+    public async Task TransientDrop_SameEngineProcess_ResumesInsteadOfEnding()
+    {
+        await using var server = new MockTcpProfilerServer { Scripted = true, CreatedUtcTicks = 4_242 };
+        server.Start();
+        using var runtime = await AttachSessionRuntime.StartAsync(
+            Guid.NewGuid(), $"127.0.0.1:{server.Port}", NullLogger.Instance, Timeout15s, CaptureMode.CherryPick);
+
+        string shutdownReason = null;
+        runtime.ShutdownReceived += r => shutdownReason = r;
+        await server.WaitForClientAsync(Timeout15s);
+
+        // Same process — CreatedUtcTicks unchanged.
+        await server.DropClientAsync();
+        var reconnected = await WaitUntilAsync(() => server.ConnectionCount >= 2, TimeSpan.FromSeconds(12));
+
+        Assert.That(reconnected, Is.True, "the runtime must reconnect after a transient drop");
+        Assert.That(shutdownReason, Is.Null, "a socket blip within one engine process must not end the session");
+        Assert.That(runtime.IsUnrecoverable, Is.False);
+    }
+
+    /// <summary>
+    /// AC-18 + AC-19 — a cherry-pick session that recorded a window auto-saves before teardown, and the saved replay
+    /// contains the ticks that were captured. AC-19's flush ordering is what makes the second half true: <c>Dispose</c>
+    /// deletes the temp file and does not flush, so without an explicit flush the most recent chunk never reaches disk.
+    /// </summary>
+    [Test]
+    public async Task CherryPickWithARecordedWindow_AutoSavesOnRestart_IncludingTheLastChunk()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout15s);
+        h.Server.CreatedUtcTicks = 10;
+
+        string savedPath = null;
+        h.Runtime.CaptureAutoSaved += p => savedPath = p;
+
+        h.Runtime.Arm(3);
+        for (var i = 0; i < 5; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(100 + i), detailRecords: 6, ct: Timeout15s);
+        }
+        await h.WaitForSummariesAsync(4);
+        Assert.That(h.Runtime.CaptureState.RecordedTicks, Is.EqualTo(3), "the window must have been recorded");
+
+        // Restart the engine.
+        h.Server.CreatedUtcTicks = 20;
+        await h.Server.DropClientAsync();
+
+        var saved = await WaitUntilAsync(() => savedPath != null, TimeSpan.FromSeconds(12));
+        Assert.That(saved, Is.True, "a recorded window must be saved before the session is torn down");
+        Assert.That(File.Exists(savedPath), Is.True, $"the replay must exist on disk at {savedPath}");
+        Assert.That(new FileInfo(savedPath!).Length, Is.GreaterThan(0), "the replay must not be empty");
+
+    }
+
+    /// <summary>
+    /// AC-18 — an attach where Record was never pressed leaves nothing behind. The guard is what stops the captures
+    /// directory filling with empty files every time someone attaches and detaches.
+    /// </summary>
+    [Test]
+    public async Task CherryPickWithNoRecordedWindow_SavesNothing()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout15s);
+        h.Server.CreatedUtcTicks = 10;
+
+        string savedPath = null;
+        h.Runtime.CaptureAutoSaved += p => savedPath = p;
+
+        for (var i = 0; i < 4; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(100 + i), detailRecords: 6, ct: Timeout15s);
+        }
+        await h.WaitForSummariesAsync(3);
+        Assert.That(h.Runtime.CaptureState.RecordedTicks, Is.Zero, "nothing was armed");
+
+        h.Server.CreatedUtcTicks = 20;
+        await h.Server.DropClientAsync();
+
+        // Give the restart path time to run and, if it were going to, save.
+        await WaitUntilAsync(() => savedPath != null, TimeSpan.FromSeconds(4));
+        Assert.That(savedPath, Is.Null, "an attach where Record was never pressed must leave no file behind");
+        Assert.That(h.Runtime.AutoSavedPath, Is.Null);
+    }
+
+    /// <summary>
+    /// AC-18 — capture-everything mode never auto-saves. That data is large and incidental; silently writing it to the
+    /// user's local-app-data on every restart is not something a tool should do unasked.
+    /// </summary>
+    [Test]
+    public async Task CaptureEverythingMode_NeverAutoSaves()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.Everything, Timeout15s);
+        h.Server.CreatedUtcTicks = 10;
+
+        string savedPath = null;
+        h.Runtime.CaptureAutoSaved += p => savedPath = p;
+
+        for (var i = 0; i < 4; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(100 + i), detailRecords: 6, ct: Timeout15s);
+        }
+        await h.WaitForSummariesAsync(3);
+        Assert.That(h.Runtime.CaptureState.RecordedTicks, Is.GreaterThan(0), "everything-mode records every tick");
+
+        h.Server.CreatedUtcTicks = 20;
+        await h.Server.DropClientAsync();
+
+        await WaitUntilAsync(() => savedPath != null, TimeSpan.FromSeconds(4));
+        Assert.That(savedPath, Is.Null, "capture-everything must prompt, not silently write GBs");
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/CaptureShutdownSaveTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/CaptureShutdownSaveTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// On-demand tick capture (#805) — what happens when the profiled application QUITS.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>CaptureRestartTests</c> covers the restart path — a socket drop followed by an <c>Init</c> carrying a new
+/// <c>CreatedUtcTicks</c>. Quitting is a different path: the engine sends a <b>Shutdown frame</b>, which runs
+/// <c>AutoSaveOnTeardown("engine_shutdown")</c> on the read loop. Nothing covered that, nor the sequence that follows it
+/// in the UI: the shutdown banner offers <i>Capture &amp; Analyse</i>, which is a SECOND save
+/// (<c>POST /save-replay</c> → <c>SaveSessionAsync</c>) on a runtime that has already auto-saved.
+/// </para>
+/// <para>
+/// The client awaits that POST with no timeout, so a server that never answers leaves the button on
+/// <c>Capturing…</c> for ever. These tests therefore assert on COMPLETION under a deadline, not merely on the result.
+/// </para>
+/// </remarks>
+[TestFixture]
+public sealed class CaptureShutdownSaveTests
+{
+    private static CancellationToken Timeout15s => new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token;
+
+    private string _capturesDir;
+    private string _previousOverride;
+
+    /// <summary>Auto-save writes real files and prunes the directory afterwards — never point it at the real archive.</summary>
+    [SetUp]
+    public void RedirectCapturesDirectory()
+    {
+        _previousOverride = Environment.GetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable);
+        _capturesDir = Path.Combine(Path.GetTempPath(), "typhon-capture-shutdown-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_capturesDir);
+        Environment.SetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable, _capturesDir);
+    }
+
+    [TearDown]
+    public void RestoreCapturesDirectory()
+    {
+        Environment.SetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable, _previousOverride);
+        try { Directory.Delete(_capturesDir, recursive: true); } catch (IOException) { /* best-effort */ }
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+            await Task.Delay(10);
+        }
+        return condition();
+    }
+
+    /// <summary>Record two windows, the way an operator does: arm, let it run, arm again.</summary>
+    private static async Task RecordTwoWindowsAsync(CaptureHarness h)
+    {
+        h.Runtime.Arm(3);
+        for (var i = 0; i < 4; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(100 + i), detailRecords: 6, ct: Timeout15s);
+        }
+
+        h.Runtime.Arm(3);
+        for (var i = 4; i < 8; i++)
+        {
+            await h.SendTickAsync(i, engineTick: (uint)(100 + i), detailRecords: 6, ct: Timeout15s);
+        }
+
+        await h.WaitForSummariesAsync(7);
+        Assert.That(h.Runtime.CaptureState.RecordedTicks, Is.EqualTo(6), "two three-tick windows must have been recorded");
+    }
+
+    /// <summary>
+    /// The reported bug: capture two windows, quit the application, then accept the banner's offer to capture the
+    /// result. The save must actually come back — the UI has no timeout behind it.
+    /// </summary>
+    [Test]
+    public async Task QuitThenCaptureAndAnalyse_CompletesInsteadOfHanging()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout15s);
+        h.Server.CreatedUtcTicks = 10;
+
+        string autoSavedPath = null;
+        h.Runtime.CaptureAutoSaved += p => autoSavedPath = p;
+
+        await RecordTwoWindowsAsync(h);
+
+        // The user quits the app — a clean Shutdown frame, not a dropped socket.
+        await h.Server.SendShutdownAsync(Timeout15s);
+        var autoSaved = await WaitUntilAsync(() => autoSavedPath != null, TimeSpan.FromSeconds(12));
+        Assert.That(autoSaved, Is.True, "quitting must auto-save the recorded window before teardown");
+
+        // The banner's Capture & Analyse button: POST /save-replay → SaveSessionAsync on the same runtime.
+        var target = Path.Combine(_capturesDir, "capture-and-analyse.typhon-replay");
+        var save = h.Runtime.SaveSessionAsync(target, CancellationToken.None);
+        var settled = await Task.WhenAny(save, Task.Delay(TimeSpan.FromSeconds(15)));
+
+        Assert.That(settled, Is.SameAs(save),
+            "Capture & Analyse never returned — the client awaits this POST with no timeout, so the button sits on 'Capturing…' for ever");
+        Assert.That(await save, Is.GreaterThan(0), "the second save must produce a non-empty replay");
+        Assert.That(File.Exists(target), Is.True);
+    }
+
+    /// <summary>
+    /// Closing the session — or pressing <i>Stop watching</i> — preserves the recorded window too.
+    /// </summary>
+    /// <remarks>
+    /// Auto-save originally ran only on the teardown FRAMES (engine shutdown, engine restart). Those are not the only
+    /// way a session ends: the operator closes it, or stops watching, and both routes reach <c>Dispose</c> having
+    /// recorded exactly the ticks they meant to. While a live run also produced a complete engine capture this only
+    /// duplicated it; with a live-only run writing nothing else, it is the difference between keeping the recording and
+    /// silently throwing it away.
+    /// </remarks>
+    [Test]
+    public async Task ClosingTheSession_SavesTheRecordedWindow()
+    {
+        string savedPath = null;
+        {
+            await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout15s);
+            h.Runtime.CaptureAutoSaved += p => savedPath = p;
+            await RecordTwoWindowsAsync(h);
+            // No shutdown frame, no restart — the session is simply disposed, as StopWatching and session close both do.
+        }
+
+        Assert.That(savedPath, Is.Not.Null, "disposing a session that recorded a window must not discard it");
+        Assert.That(File.Exists(savedPath), Is.True);
+        Assert.That(new FileInfo(savedPath).Length, Is.GreaterThan(0));
+    }
+
+    /// <summary>An attach where Record was never pressed still leaves nothing behind when it is closed.</summary>
+    [Test]
+    public async Task ClosingASessionThatRecordedNothing_WritesNoFile()
+    {
+        string savedPath = null;
+        {
+            await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout15s);
+            h.Runtime.CaptureAutoSaved += p => savedPath = p;
+            for (var i = 0; i < 3; i++)
+            {
+                await h.SendTickAsync(i, engineTick: (uint)(100 + i), detailRecords: 6, ct: Timeout15s);
+            }
+            await h.WaitForSummariesAsync(2);
+        }
+
+        Assert.That(savedPath, Is.Null, "closing an idle session must not litter the captures directory");
+    }
+
+    /// <summary>
+    /// The same save, without the preceding quit. Isolates the auto-save from the save: if this passes and the test
+    /// above hangs, the teardown path is what breaks the later one.
+    /// </summary>
+    [Test]
+    public async Task SaveWhileStillLive_Completes()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout15s);
+        h.Server.CreatedUtcTicks = 10;
+
+        await RecordTwoWindowsAsync(h);
+
+        var target = Path.Combine(_capturesDir, "live-save.typhon-replay");
+        var save = h.Runtime.SaveSessionAsync(target, CancellationToken.None);
+        var settled = await Task.WhenAny(save, Task.Delay(TimeSpan.FromSeconds(15)));
+
+        Assert.That(settled, Is.SameAs(save), "a save on a live session must return");
+        Assert.That(await save, Is.GreaterThan(0));
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/CaptureStorageRetentionTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/CaptureStorageRetentionTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Typhon.Engine;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// AC-20 — retention over the Workbench captures directory (#805).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The #613 <c>profilings/</c> retention does not reach attach captures: that path is resolved from a database file
+/// path and an attach session's is a <c>host:port</c> endpoint, and <c>TraceRetention.Prune</c> enumerates
+/// <c>*.typhon-trace</c> rather than the self-contained <c>.typhon-replay</c> files written here. What is shared is
+/// <see cref="RetentionPolicy"/> itself — same record, same <c>retention.json</c>, same semantics.
+/// </para>
+/// <para>
+/// Every test here redirects the captures directory to a temp folder. Without that they would prune the developer's
+/// real capture archive, which is a destructive side effect no test is entitled to.
+/// </para>
+/// </remarks>
+[TestFixture]
+public sealed class CaptureStorageRetentionTests
+{
+    private string _dir;
+    private string _previousOverride;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _previousOverride = Environment.GetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable);
+        _dir = Path.Combine(Path.GetTempPath(), "typhon-capture-retention-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        Environment.SetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable, _dir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable(CaptureStorage.DirectoryOverrideVariable, _previousOverride);
+        try { Directory.Delete(_dir, recursive: true); } catch (IOException) { /* best-effort */ }
+    }
+
+    private string WriteCapture(string name, int bytes, DateTime lastWriteUtc)
+    {
+        var path = Path.Combine(_dir, name + CaptureStorage.ReplayExtension);
+        File.WriteAllBytes(path, new byte[bytes]);
+        File.SetLastWriteTimeUtc(path, lastWriteUtc);
+        return path;
+    }
+
+    private string[] RemainingCaptures() =>
+        [.. Directory.EnumerateFiles(_dir, "*" + CaptureStorage.ReplayExtension).Select(Path.GetFileName).Order()];
+
+    [Test]
+    public void ApplyRetention_EvictsOldestFirst_UntilWithinBudget()
+    {
+        new RetentionPolicy { BudgetBytes = 300, KeepLatest = 1 }.Write(_dir);
+
+        var now = DateTime.UtcNow;
+        WriteCapture("oldest", 200, now.AddMinutes(-30));
+        WriteCapture("middle", 200, now.AddMinutes(-20));
+        var newest = WriteCapture("newest", 200, now.AddMinutes(-10));
+
+        CaptureStorage.ApplyRetention(newest, _ => { });
+
+        var remaining = RemainingCaptures();
+        Assert.That(remaining, Does.Not.Contain("oldest" + CaptureStorage.ReplayExtension), "the oldest capture must be evicted first");
+        Assert.That(remaining, Contains.Item("newest" + CaptureStorage.ReplayExtension), "the newest capture must survive");
+    }
+
+    [Test]
+    public void ApplyRetention_NeverDeletesTheCaptureJustWritten()
+    {
+        // A budget far below a single file's size: without the guard, the file that triggered the prune is the obvious
+        // eviction candidate, and capturing would silently produce nothing.
+        new RetentionPolicy { BudgetBytes = 1, KeepLatest = 0 }.Write(_dir);
+
+        var justWritten = WriteCapture("fresh", 500, DateTime.UtcNow);
+        CaptureStorage.ApplyRetention(justWritten, _ => { });
+
+        Assert.That(File.Exists(justWritten), Is.True,
+            "evicting the capture whose creation triggered the prune would make capturing unreliable rather than bounded");
+    }
+
+    [Test]
+    public void ApplyRetention_HonoursKeepLatestFloor_EvenOverBudget()
+    {
+        new RetentionPolicy { BudgetBytes = 1, KeepLatest = 3 }.Write(_dir);
+
+        var now = DateTime.UtcNow;
+        WriteCapture("a", 100, now.AddMinutes(-40));
+        WriteCapture("b", 100, now.AddMinutes(-30));
+        WriteCapture("c", 100, now.AddMinutes(-20));
+        var d = WriteCapture("d", 100, now.AddMinutes(-10));
+
+        CaptureStorage.ApplyRetention(d, _ => { });
+
+        Assert.That(RemainingCaptures(), Has.Length.GreaterThanOrEqualTo(3),
+            "KeepLatest is a floor: the newest captures survive even when that exceeds the budget");
+    }
+
+    [Test]
+    public void ApplyRetention_NeverEvictsAPinnedCapture()
+    {
+        new RetentionPolicy
+        {
+            BudgetBytes = 1,
+            KeepLatest = 0,
+            Pinned = ["keepme" + CaptureStorage.ReplayExtension],
+        }.Write(_dir);
+
+        var now = DateTime.UtcNow;
+        WriteCapture("keepme", 500, now.AddMinutes(-40));
+        var newest = WriteCapture("disposable", 100, now.AddMinutes(-1));
+
+        CaptureStorage.ApplyRetention(newest, _ => { });
+
+        Assert.That(RemainingCaptures(), Contains.Item("keepme" + CaptureStorage.ReplayExtension),
+            "a pinned capture counts toward the budget but is never evicted");
+    }
+
+    [Test]
+    public void ApplyRetention_WithNonPositiveBudget_DeletesNothing()
+    {
+        new RetentionPolicy { BudgetBytes = 0, KeepLatest = 0 }.Write(_dir);
+
+        var now = DateTime.UtcNow;
+        WriteCapture("a", 5_000, now.AddMinutes(-40));
+        var b = WriteCapture("b", 5_000, now.AddMinutes(-1));
+
+        CaptureStorage.ApplyRetention(b, _ => { });
+
+        Assert.That(RemainingCaptures(), Has.Length.EqualTo(2), "a non-positive budget disables eviction, per the policy's contract");
+    }
+
+    /// <summary>
+    /// Retention prunes the directory the capture landed in, not the machine-local default.
+    /// </summary>
+    /// <remarks>
+    /// A session with a database saves into that database's <c>profilings/</c>. Reading the default directory here
+    /// would prune an unrelated folder while the one that just grew went unbounded — and worse, <c>justWritten</c>
+    /// would match nothing in the scanned folder, so the "never evict what we just wrote" guard would be silently off.
+    /// </remarks>
+    [Test]
+    public void ApplyRetention_PrunesTheDirectoryTheCaptureWasWrittenTo()
+    {
+        var profilings = Path.Combine(_dir, "world.typhon", "profilings");
+        Directory.CreateDirectory(profilings);
+        new RetentionPolicy { BudgetBytes = 300, KeepLatest = 1 }.Write(profilings);
+
+        var now = DateTime.UtcNow;
+        string Write(string name, int bytes, DateTime stamp)
+        {
+            var p = Path.Combine(profilings, name + CaptureStorage.ReplayExtension);
+            File.WriteAllBytes(p, new byte[bytes]);
+            File.SetLastWriteTimeUtc(p, stamp);
+            return p;
+        }
+
+        Write("old", 200, now.AddMinutes(-30));
+        Write("mid", 200, now.AddMinutes(-20));
+        var newest = Write("new", 200, now.AddMinutes(-10));
+
+        CaptureStorage.ApplyRetention(newest, _ => { });
+
+        var remaining = Directory.EnumerateFiles(profilings, "*" + CaptureStorage.ReplayExtension).Select(Path.GetFileName).ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(remaining, Does.Not.Contain("old" + CaptureStorage.ReplayExtension), "the directory that grew is the one that must be pruned");
+            Assert.That(remaining, Contains.Item("new" + CaptureStorage.ReplayExtension), "and the capture that triggered the prune is never its own victim");
+        });
+    }
+
+    /// <summary>
+    /// Pruning a database's <c>profilings/</c> must never touch an engine-written capture.
+    /// </summary>
+    /// <remarks>
+    /// This is the safety property that lets the two retention policies share a directory at all: this pass scans
+    /// <c>*.typhon-replay</c> and engine-side <c>TraceRetention</c> scans <c>*.typhon-trace</c>, so each file kind has
+    /// exactly one owner. If this ever fails, the Workbench is deleting post-mortem captures it did not write and has
+    /// no budget information about — silently, from inside a save.
+    /// </remarks>
+    [Test]
+    public void ApplyRetention_NeverEvictsAnEngineWrittenTrace()
+    {
+        var profilings = Path.Combine(_dir, "world.typhon", "profilings");
+        Directory.CreateDirectory(profilings);
+        new RetentionPolicy { BudgetBytes = 1, KeepLatest = 1 }.Write(profilings);
+
+        var enginePath = Path.Combine(profilings, "20260815-120000-000.typhon-trace");
+        File.WriteAllBytes(enginePath, new byte[10_000]);
+        File.SetLastWriteTimeUtc(enginePath, DateTime.UtcNow.AddDays(-9));
+
+        var replay = Path.Combine(profilings, "typhon-autosave-x" + CaptureStorage.ReplayExtension);
+        File.WriteAllBytes(replay, new byte[10_000]);
+
+        CaptureStorage.ApplyRetention(replay, _ => { });
+
+        Assert.That(File.Exists(enginePath), Is.True,
+            "a budget of 1 byte would evict everything it can see — an engine capture must not be one of those things");
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/CaptureTickNumberingTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/CaptureTickNumberingTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Typhon.Workbench.Fixtures;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// On-demand tick capture (#805) — absolute tick numbering. Covers AC-8 (attach mid-run reports true simulation ticks),
+/// AC-9 (no gauges ⇒ relative numbering, honestly flagged) and AC-10 (a dropped <c>TickStart</c> is detected rather than
+/// silently renumbering the rest of the session).
+/// </summary>
+/// <remarks>
+/// The builder derives tick numbers by counting <c>TickStart</c> markers from zero, so a session that attaches to an
+/// engine already an hour into its run calls the first tick it sees "tick 1". The only absolute tick number anywhere on
+/// the live wire is the one <c>PerTickSnapshot</c> carries at record offset 12, written straight from
+/// <c>scheduler.CurrentTickNumber</c> — which is why the gauge record is exempt from filtering even though it is the
+/// fattest thing in the exempt set.
+/// </remarks>
+[TestFixture]
+public sealed class CaptureTickNumberingTests
+{
+    private static CancellationToken Timeout10s => new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+
+    /// <summary>AC-8 — attaching to an engine mid-run reports the engine's tick numbers, not attach-relative ones.</summary>
+    [Test]
+    public async Task AttachMidRun_ReportsTrueSimulationTickNumbers()
+    {
+        const uint firstEngineTick = 216_000;   // ~1 hour in at 60 Hz
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await h.SendTickAsync(i, engineTick: firstEngineTick + (uint)i, ct: Timeout10s);
+        }
+        await h.WaitForSummariesAsync(4);
+
+        var summaries = h.Summaries;
+        Assert.That(h.Runtime.CaptureState.TickNumbersAbsolute, Is.True, "the gauge record must have established the offset");
+
+        Assert.That(summaries[0].TickNumber, Is.EqualTo(firstEngineTick),
+            "the first reported tick must be the engine's tick, not 1");
+
+        for (var i = 0; i < summaries.Count; i++)
+        {
+            Assert.That(summaries[i].TickNumber, Is.EqualTo(firstEngineTick + (uint)i),
+                $"tick {i} must carry the engine's absolute number; got [{string.Join(", ", summaries.Select(s => s.TickNumber))}]");
+        }
+
+        Assert.That(h.Runtime.CaptureState.TickNumberingSuspect, Is.False, "numbering must be trusted when nothing was dropped");
+    }
+
+    /// <summary>
+    /// AC-8 (manifest coherence) — the chunk manifest must be translated with the summaries. The client maps a
+    /// microsecond range to a tick range via <c>tickSummaries</c> and then selects chunks by comparing against the
+    /// manifest's tick range, so translating one and not the other would silently mis-map chunks to ticks.
+    /// </summary>
+    [Test]
+    public async Task ChunkManifest_UsesTheSameAbsoluteTickNumbersAsTheSummaries()
+    {
+        const uint firstEngineTick = 500_000;
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.Everything, Timeout10s);
+
+        for (var i = 0; i < 6; i++)
+        {
+            await h.SendTickAsync(i, engineTick: firstEngineTick + (uint)i, detailRecords: 2, ct: Timeout10s);
+        }
+        await h.WaitForSummariesAsync(5);
+
+        // Force the in-flight chunk out so the manifest has an entry to inspect.
+        var metadata = h.Runtime.Metadata;
+        Assert.That(metadata, Is.Not.Null);
+
+        var summaryMin = h.Summaries.Min(s => s.TickNumber);
+        Assert.That(summaryMin, Is.GreaterThanOrEqualTo(firstEngineTick),
+            "summaries must be in absolute tick space");
+
+        foreach (var entry in metadata.ChunkManifest)
+        {
+            Assert.That(entry.FromTick, Is.GreaterThanOrEqualTo(firstEngineTick),
+                $"chunk manifest must be in the same absolute tick space as the summaries; got fromTick={entry.FromTick}");
+        }
+    }
+
+    /// <summary>
+    /// AC-9 — an engine running without gauges publishes no absolute tick number anywhere, so numbering stays
+    /// attach-relative. That must be reported honestly rather than presented as if it were absolute.
+    /// </summary>
+    [Test]
+    public async Task WithoutGauges_NumberingStaysRelative_AndSaysSo()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await h.SendTickAsync(i, engineTick: 900_000 + (uint)i, includeGauges: false, ct: Timeout10s);
+        }
+        await h.WaitForSummariesAsync(4);
+
+        var state = h.Runtime.CaptureState;
+        Assert.Multiple(() =>
+        {
+            Assert.That(state.TickNumbersAbsolute, Is.False, "no gauge record ⇒ no absolute tick number is available");
+            Assert.That(state.TickNumberingSuspect, Is.False, "relative numbering is a known limitation, not a fault");
+        });
+
+        Assert.That(h.Summaries[0].TickNumber, Is.EqualTo(1u),
+            "without gauges the timeline is numbered from the attach point, and the UI must label it as such");
+    }
+
+    /// <summary>
+    /// AC-10 — a lost <c>TickStart</c> is the one silent-corruption mode this design could introduce: the derived count
+    /// falls behind and every later tick number is wrong, with nothing in the data looking unusual. The gauge record's
+    /// absolute tick number is used as an independent oracle so the session says so instead.
+    /// </summary>
+    [Test]
+    public async Task DroppedTickStart_IsDetected_RatherThanSilentlyRenumbering()
+    {
+        await using var h = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout10s);
+
+        // Two well-formed ticks establish the offset.
+        await h.SendTickAsync(0, engineTick: 100, ct: Timeout10s);
+        await h.SendTickAsync(1, engineTick: 101, ct: Timeout10s);
+        await h.WaitForSummariesAsync(1);
+        Assert.That(h.Runtime.CaptureState.TickNumberingSuspect, Is.False, "no drift yet");
+
+        // A tick whose TickStart never arrived — the engine advanced, our derived counter did not.
+        await h.SendBlockAsync(MockRecordFactory.Concat(
+            MockRecordFactory.TickEnd(CaptureHarness.At(25_000)),
+            MockRecordFactory.PerTickSnapshot(CaptureHarness.At(25_010), engineTickNumber: 102),
+            MockRecordFactory.MetronomeWait(CaptureHarness.At(29_000), durationTicks: 200)), Timeout10s);
+
+        Assert.That(h.Runtime.CaptureState.TickNumberingSuspect, Is.True,
+            "a TickStart gap must be surfaced — a plausible-looking renumbered timeline is worse than an admitted one");
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/ProfileCatalogReplayTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/ProfileCatalogReplayTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Typhon.Workbench.Services;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// A cherry-picked window saved into a database's <c>profilings/</c> must be findable and openable there.
+/// </summary>
+/// <remarks>
+/// <para>
+/// With the engine writing no file for a live-only run, this replay is the <b>only</b> artifact of a recording session.
+/// If the Profiles list — the one surface built for finding captures — does not show it, the operator's deliberately
+/// armed ticks are invisible; if it shows it but refuses to attach it, that is worse still, because the tool then
+/// advertises something it will not open.
+/// </para>
+/// <para>
+/// The replay is produced by actually saving one, not by hand-crafting bytes: what is under test is whether the
+/// catalog's header projection agrees with what <c>SaveSessionAsync</c> writes, and a fixture file would only prove
+/// the projection agrees with itself.
+/// </para>
+/// </remarks>
+[TestFixture]
+public sealed class ProfileCatalogReplayTests
+{
+    private static CancellationToken Timeout15s => new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token;
+
+    private string _root;
+    private string _bundle;
+    private string _profilings;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "typhon-catalog-replay-" + Guid.NewGuid().ToString("N"));
+        _bundle = Path.Combine(_root, "world.typhon");
+        _profilings = Typhon.Engine.TraceLocation.ProfilingsDirectoryOf(_bundle);
+        Directory.CreateDirectory(_profilings);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch (IOException) { /* best-effort */ }
+    }
+
+    private OpenSession PausedSessionOnBundle() => new(
+        Guid.NewGuid(),
+        _bundle,
+        new DatabaseHolder(Environment.ProcessId, Environment.MachineName, DateTimeOffset.UtcNow, "localhost:9100"),
+        []);
+
+    /// <summary>Records a short window and saves it where a watching session would.</summary>
+    private async Task<string> SaveRecordedWindowAsync()
+    {
+        await using var harness = await CaptureHarness.StartAsync(CaptureMode.CherryPick, Timeout15s);
+        harness.Runtime.Arm(3);
+        for (var i = 0; i < 4; i++)
+        {
+            await harness.SendTickAsync(i, engineTick: (uint)(500 + i), detailRecords: 6, ct: Timeout15s);
+        }
+        await harness.WaitForSummariesAsync(3);
+
+        var path = Path.Combine(_profilings, "typhon-autosave-catalog-test" + CaptureStorage.ReplayExtension);
+        var bytes = await harness.Runtime.SaveSessionAsync(path, Timeout15s);
+        Assert.That(bytes, Is.GreaterThan(0), "the fixture must actually produce a replay");
+        return path;
+    }
+
+    [Test]
+    public async Task ARecordedWindowSavedIntoProfilings_AppearsInTheProfilesList()
+    {
+        var replay = await SaveRecordedWindowAsync();
+        var session = PausedSessionOnBundle();
+
+        var list = ProfileCatalog.List(session);
+        var row = list.Profiles.SingleOrDefault(p => p.FileName == Path.GetFileName(replay));
+
+        Assert.That(row, Is.Not.Null, "the recorded window is the only artifact of a live-only run — it has to be listed");
+        Assert.That(row.IsReadable, Is.True,
+            "and listed with its real columns: a replay embeds the same TraceFileHeader, so nothing has to degrade to an unreadable row");
+        session.Dispose();
+    }
+
+    [Test]
+    public async Task ARecordedWindow_PassesTheProvenanceCheckUsedWhenAttaching()
+    {
+        var replay = await SaveRecordedWindowAsync();
+
+        var accepted = ProfileCatalog.BelongsToDatabase(replay, Guid.Empty, out var reason);
+
+        Assert.That(accepted, Is.True,
+            $"a listed capture must be attachable — reading it with the trace-only reader would reject it as unreadable ({reason})");
+        Assert.That(reason, Is.Null);
+    }
+
+    /// <summary>
+    /// Engine-written captures keep listing exactly as before — the replay pass is additive, not a replacement.
+    /// </summary>
+    [Test]
+    public async Task ListingReplays_DoesNotDisturbEngineWrittenCaptures()
+    {
+        var replay = await SaveRecordedWindowAsync();
+        // A file with the trace extension that is NOT a valid trace: it must still list (as unreadable), which is the
+        // pre-existing contract for a capture truncated mid-write.
+        var bogusTrace = Path.Combine(_profilings, "20260815-120000-000.typhon-trace");
+        await File.WriteAllBytesAsync(bogusTrace, new byte[64]);
+
+        var session = PausedSessionOnBundle();
+        var list = ProfileCatalog.List(session);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(list.Profiles.Any(p => p.FileName == Path.GetFileName(replay)), Is.True);
+            Assert.That(list.Profiles.Any(p => p.FileName == Path.GetFileName(bogusTrace)), Is.True,
+                "an unreadable trace still gets a row so the user can see the file exists");
+        });
+        session.Dispose();
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/WatchableSessionDtoTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/WatchableSessionDtoTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Typhon.Workbench.Dtos.Sessions;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// P5 — the client's test for "can this paused database be watched?" is <see cref="SessionDto.ProfilerEndpoint"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The endpoint is read from the holder's <c>db.lock</c>, so a non-null value means the process holding this database
+/// is advertising a profiler port. Before P5 that fact lived only on <c>DatabaseHolder.IsWatchable</c>, server-side,
+/// which is why the paused banner could not offer to watch anything.
+/// </para>
+/// <para>
+/// These register a session directly with <see cref="SessionManager.Create"/> rather than driving a real pause: the
+/// mapping under test reads <c>PausedBy</c>, and a genuine pause needs a second process holding a real database — which
+/// is what makes <c>DatabasePauseTests</c> heavy enough to be quarantined (#811). The paused <c>OpenSession</c>
+/// constructor takes the holder directly and opens no engine, so the DTO can be exercised end-to-end through the real
+/// endpoint for the cost of a dictionary insert.
+/// </para>
+/// </remarks>
+[TestFixture]
+public sealed class WatchableSessionDtoTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private WorkbenchFactory _factory;
+    private HttpClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new WorkbenchFactory();
+        _client = _factory.CreateAuthenticatedClient();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    private OpenSession RegisterPaused(string profilerEndpoint)
+    {
+        var session = new OpenSession(
+            Guid.NewGuid(),
+            @"C:\nowhere\world-shard.typhon",
+            new DatabaseHolder(Environment.ProcessId, Environment.MachineName, DateTimeOffset.UtcNow, profilerEndpoint),
+            []);
+        _factory.Services.GetRequiredService<SessionManager>().Create(session);
+        return session;
+    }
+
+    private async Task<SessionDto> GetDtoAsync(Guid id)
+    {
+        // Session-scoped routes are gated by RequireSession on top of the bootstrap token: the per-session token must
+        // match the id in the route, so session A's token cannot address session B.
+        using var req = new HttpRequestMessage(HttpMethod.Get, $"/api/sessions/{id}");
+        req.Headers.Add("X-Session-Token", id.ToString());
+        var resp = await _client.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return JsonSerializer.Deserialize<SessionDto>(await resp.Content.ReadAsStringAsync(), Json);
+    }
+
+    [Test]
+    public async Task PausedByAHolderAdvertisingAPort_ReportsTheEndpoint()
+    {
+        var session = RegisterPaused("localhost:9100");
+
+        var dto = await GetDtoAsync(session.Id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dto.IsPaused, Is.True, "the session must still present as paused");
+            Assert.That(dto.ProfilerEndpoint, Is.EqualTo("localhost:9100"), "the client offers 'Watch live' on exactly this field");
+            Assert.That(dto.IsWatchingLive, Is.False, "advertising a port is not the same as watching it");
+        });
+    }
+
+    /// <summary>
+    /// The ordinary pause: something holds the database but is not a Typhon app with a live port — an editor, a backup,
+    /// an older build. Offering to watch it would produce a connection refused, so the field must stay null.
+    /// </summary>
+    [Test]
+    public async Task PausedByAHolderWithNoPort_ReportsNoEndpoint()
+    {
+        var session = RegisterPaused(null);
+
+        var dto = await GetDtoAsync(session.Id);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dto.IsPaused, Is.True);
+            Assert.That(dto.ProfilerEndpoint, Is.Null);
+            Assert.That(dto.IsWatchingLive, Is.False);
+        });
+    }
+
+    /// <summary>
+    /// A blank endpoint is the same as none. `DatabaseLockFile` omits the property when null, but a hand-edited or
+    /// truncated lock can still yield whitespace, and `IsWatchable` already treats that as unwatchable.
+    /// </summary>
+    [Test]
+    public async Task PausedByAHolderWithABlankPort_ReportsItAsUnwatchable()
+    {
+        var session = RegisterPaused("   ");
+
+        var dto = await GetDtoAsync(session.Id);
+        Assert.That(session.PausedBy.IsWatchable, Is.False, "blank is not an endpoint");
+        Assert.That(string.IsNullOrWhiteSpace(dto.ProfilerEndpoint), Is.True);
+    }
+
+    /// <summary>
+    /// The fields are applied in `ToDto` for every session, so a non-Open session must map cleanly rather than throw on
+    /// the cast — an attach session has no holder by construction.
+    /// </summary>
+    [Test]
+    public async Task AnAttachSession_ReportsNeitherEndpointNorWatching()
+    {
+        await using var server = new Workbench.Fixtures.MockTcpProfilerServer();
+        server.Start();
+
+        var resp = await _client.PostAsJsonAsync(
+            "/api/sessions/attach", new CreateAttachSessionRequest($"127.0.0.1:{server.Port}"));
+        resp.EnsureSuccessStatusCode();
+        var created = JsonSerializer.Deserialize<SessionDto>(await resp.Content.ReadAsStringAsync(), Json);
+
+        var dto = await GetDtoAsync(created.SessionId);
+        Assert.Multiple(() =>
+        {
+            Assert.That(dto.ProfilerEndpoint, Is.Null);
+            Assert.That(dto.IsWatchingLive, Is.False);
+        });
+    }
+}

--- a/test/Typhon.Workbench.Tests/Sessions/WatchingOpenSessionTests.cs
+++ b/test/Typhon.Workbench.Tests/Sessions/WatchingOpenSessionTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Typhon.Profiler;
+using Typhon.Workbench.Fixtures;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Sessions;
+
+/// <summary>
+/// Live attach as a capability of a database session — the unified mode.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pairing: your application holds the database, so the session opened <b>paused</b> (#621). From there it watches
+/// the application's live profiler, and when the application exits the coordinator promotes the session to a real open —
+/// at which point the database and the capture the engine wrote into its own <c>profilings/</c> are both available.
+/// </para>
+/// <para>
+/// The property these tests pin is that <b>kind is not the question</b>. An <see cref="OpenSession"/> that is watching
+/// serves the profiler exactly as an <see cref="AttachSession"/> does, because #617 moved that decision onto
+/// <see cref="SessionCapability"/> precisely so a capability could be acquired and released while the kind never changes.
+/// </para>
+/// </remarks>
+[TestFixture]
+public sealed class WatchingOpenSessionTests
+{
+    private static CancellationToken Timeout10s => new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+
+    private static OpenSession PausedSession(string profilerEndpoint) =>
+        new(Guid.NewGuid(), @"C:\nowhere\world.typhon",
+            new DatabaseHolder(4242, Environment.MachineName, DateTimeOffset.UtcNow, profilerEndpoint), []);
+
+    [Test]
+    public void APausedSessionWithNoLiveRuntime_DoesNotClaimTheProfilerCapability()
+    {
+        var session = PausedSession("localhost:9100");
+        Assert.Multiple(() =>
+        {
+            Assert.That(session.IsPaused, Is.True);
+            Assert.That(session.IsWatchingLive, Is.False);
+            Assert.That(session.LiveRuntime, Is.Null);
+            Assert.That(session.Capabilities, Does.Not.Contain(SessionCapability.Profiler),
+                "advertising a profiler it is not connected to would light up panels with nothing behind them");
+        });
+    }
+
+    [Test]
+    public async Task WatchingAPausedSession_AcquiresTheProfilerCapability()
+    {
+        await using var server = new MockTcpProfilerServer { Scripted = true };
+        server.Start();
+
+        var session = PausedSession($"127.0.0.1:{server.Port}");
+        var runtime = await AttachSessionRuntime.StartAsync(
+            session.Id, $"127.0.0.1:{server.Port}", NullLogger.Instance, Timeout10s, CaptureMode.CherryPick);
+        session.StartWatching(runtime);
+
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(session.IsWatchingLive, Is.True);
+                Assert.That(session.Capabilities, Contains.Item(SessionCapability.Profiler),
+                    "a watching database session profiles, and panels ask for the capability rather than the kind");
+                Assert.That(session.Kind, Is.EqualTo(SessionKind.Open), "and it is still an Open session — the kind never changes");
+            });
+
+            // The seam every profiler handler now resolves through.
+            Assert.That(session, Is.InstanceOf<ILiveProfilerHost>());
+            Assert.That(((ILiveProfilerHost)session).LiveRuntime, Is.SameAs(runtime));
+        }
+        finally
+        {
+            session.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task StopWatching_ReleasesTheCapability_AndIsIdempotent()
+    {
+        await using var server = new MockTcpProfilerServer { Scripted = true };
+        server.Start();
+
+        var session = PausedSession($"127.0.0.1:{server.Port}");
+        session.StartWatching(await AttachSessionRuntime.StartAsync(
+            session.Id, $"127.0.0.1:{server.Port}", NullLogger.Instance, Timeout10s, CaptureMode.CherryPick));
+
+        Assert.That(session.StopWatching(), Is.True, "the first stop had something to stop");
+        Assert.Multiple(() =>
+        {
+            Assert.That(session.IsWatchingLive, Is.False);
+            Assert.That(session.Capabilities, Does.Not.Contain(SessionCapability.Profiler));
+            Assert.That(session.StopWatching(), Is.False, "stopping twice is a no-op, not an error");
+        });
+        session.Dispose();
+    }
+
+    /// <summary>
+    /// A watching database session auto-saves its recorded window INTO that database's <c>profilings/</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This assertion is inverted from what it originally said</b>, and the original was built on a defect. It read
+    /// "a database session already gets a complete capture from the engine, so a second copy is redundant" — true only
+    /// because a live port had been made to force a default file destination. That forcing was itself the bug: it wrote
+    /// 25.84 MB beside the database while the operator had deliberately recorded a 1.04 MB window, which is the exact
+    /// opposite of what on-demand capture is for.
+    /// </para>
+    /// <para>
+    /// With the engine writing nothing for a live-only run, the recorded window is the <b>only</b> artifact. Suppressing
+    /// its save would silently discard the very ticks the operator armed, and writing it to local-app-data would hide it
+    /// from the Profiles list. It belongs beside the database it was recorded from.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task AWatchingDatabaseSession_AutoSavesIntoTheDatabasesProfilingsDirectory()
+    {
+        await using var server = new MockTcpProfilerServer { Scripted = true };
+        server.Start();
+
+        var session = PausedSession($"127.0.0.1:{server.Port}");
+        var runtime = await AttachSessionRuntime.StartAsync(
+            session.Id, $"127.0.0.1:{server.Port}", NullLogger.Instance, Timeout10s, CaptureMode.CherryPick);
+
+        Assert.That(runtime.AutoSaveDirectory, Is.Null, "an unattached runtime has no database, so it falls back to the captures directory");
+        session.StartWatching(runtime);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(runtime.SuppressAutoSave, Is.False, "the recorded window is the only artifact — nothing else would preserve it");
+            Assert.That(runtime.AutoSaveDirectory, Is.EqualTo(TraceLocation.ProfilingsDirectoryOf(session.FilePath)),
+                "and it must land where the Profiles list looks, not in local-app-data");
+        });
+
+        session.Dispose();
+    }
+
+    [Test]
+    public void AHolderThatAdvertisesNoProfiler_IsNotWatchable()
+    {
+        var withEndpoint = new DatabaseHolder(1, "HOST", DateTimeOffset.UtcNow, "localhost:9100");
+        var without = new DatabaseHolder(1, "HOST", DateTimeOffset.UtcNow);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(withEndpoint.IsWatchable, Is.True);
+            Assert.That(without.IsWatchable, Is.False, "an application running without a live port offers nothing to watch");
+            Assert.That(without.ProfilerEndpoint, Is.Null);
+        });
+    }
+}

--- a/tools/Typhon.Workbench.Fixtures/MockRecordFactory.cs
+++ b/tools/Typhon.Workbench.Fixtures/MockRecordFactory.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Text;
+using Typhon.Profiler;
+
+namespace Typhon.Workbench.Fixtures;
+
+/// <summary>
+/// Builds individual profiler wire records byte-for-byte, so tests can compose an arbitrary engine record stream without
+/// running an engine. Every layout here mirrors what <see cref="Typhon.Profiler.IncrementalCacheBuilder"/> parses — the
+/// builder is the consumer under test, so a record that it would reject is a record this factory must not produce.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why hand-assembled.</b> The production encoders live behind <c>internal</c> producer ref structs in
+/// <c>Typhon.Engine</c> that require a claimed <c>ThreadSlot</c> and a live ring buffer. A fixture cannot reach them, and
+/// standing up a real engine to emit six records would make every filter test an integration test. The layouts are
+/// small, fixed, and asserted against the builder's own parse offsets by <c>MockRecordFactoryTests</c>.
+/// </para>
+/// <para>
+/// <b>Layouts.</b> Common header (12 B) on every record: <c>u16 size</c>, <c>u8 kind</c>, <c>u8 threadSlot</c>,
+/// <c>i64 startTimestamp</c>. Span records append a 25 B extension: <c>i64 durationTicks</c>, <c>u64 spanId</c>,
+/// <c>u64 parentSpanId</c>, <c>u8 spanFlags</c> — payload then starts at offset 37 when the trace-context bit is clear.
+/// </para>
+/// </remarks>
+public static class MockRecordFactory
+{
+    /// <summary>Common record header size — mirrors <c>TraceRecordHeader.CommonHeaderSize</c>.</summary>
+    public const int CommonHeaderSize = 12;
+
+    /// <summary>Span header extension size — mirrors <c>TraceRecordHeader.SpanHeaderExtensionSize</c>.</summary>
+    public const int SpanHeaderExtSize = 25;
+
+    /// <summary>Offset at which a span record's payload begins when it carries no trace context.</summary>
+    public const int SpanPayloadOffset = CommonHeaderSize + SpanHeaderExtSize;
+
+    /// <summary>
+    /// The kinds <c>AttachSessionRuntime</c> must never filter, whatever the arm state. Mirrors the exempt set in
+    /// <c>claude/design/Profiler/12-on-demand-tick-capture.md</c> §4.1 — kept here so tests can assert against a single
+    /// declaration rather than a literal list repeated per test.
+    /// </summary>
+    public static readonly TraceEventKind[] ExemptKinds =
+    [
+        TraceEventKind.TickStart,
+        TraceEventKind.TickEnd,
+        TraceEventKind.PerTickSnapshot,
+        TraceEventKind.ThreadInfo,
+        TraceEventKind.SchedulerMetronomeWait,
+        TraceEventKind.SchedulerOverloadDetector,
+    ];
+
+    /// <summary><see cref="TraceEventKind.TickStart"/> — 12 B, header only, no payload.</summary>
+    public static byte[] TickStart(long timestamp, byte threadSlot = 0)
+    {
+        var record = new byte[CommonHeaderSize];
+        WriteCommonHeader(record, (ushort)record.Length, TraceEventKind.TickStart, threadSlot, timestamp);
+        return record;
+    }
+
+    /// <summary><see cref="TraceEventKind.TickEnd"/> — 14 B: header + <c>u8 overloadLevel</c> + <c>u8 tickMultiplier</c>.</summary>
+    public static byte[] TickEnd(long timestamp, byte overloadLevel = 0, byte tickMultiplier = 1, byte threadSlot = 0)
+    {
+        var record = new byte[CommonHeaderSize + 2];
+        WriteCommonHeader(record, (ushort)record.Length, TraceEventKind.TickEnd, threadSlot, timestamp);
+        record[CommonHeaderSize] = overloadLevel;
+        record[CommonHeaderSize + 1] = tickMultiplier;
+        return record;
+    }
+
+    /// <summary>
+    /// <see cref="TraceEventKind.SchedulerMetronomeWait"/> (241) — a 48 B <b>span</b>. Payload after the span extension:
+    /// <c>i64 scheduledTs</c>, <c>u8 multiplier</c>, <c>u8 intentClass</c>, <c>u8 phaseFlags</c>.
+    /// </summary>
+    /// <remarks>
+    /// Load-bearing for duration parity: the builder lets this record's <c>startTimestamp</c> push
+    /// <c>_currentTickLastTs</c> forward before sealing the tick, so a tick finalized without it reports a shorter
+    /// duration than one finalized with it. See design §4.1.
+    /// </remarks>
+    public static byte[] MetronomeWait(long startTimestamp, long durationTicks, byte tickMultiplier = 1, byte intentClass = 0, byte threadSlot = 0)
+    {
+        var record = new byte[SpanPayloadOffset + 11];
+        WriteSpanHeader(record, (ushort)record.Length, TraceEventKind.SchedulerMetronomeWait, threadSlot, startTimestamp, durationTicks);
+        BinaryPrimitives.WriteInt64LittleEndian(record.AsSpan(SpanPayloadOffset), startTimestamp);
+        record[SpanPayloadOffset + 8] = tickMultiplier;
+        record[SpanPayloadOffset + 9] = intentClass;
+        record[SpanPayloadOffset + 10] = 0;
+        return record;
+    }
+
+    /// <summary>
+    /// <see cref="TraceEventKind.SchedulerOverloadDetector"/> (242) — a 36 B instant. Payload: <c>i64 tick</c>,
+    /// <c>f32 overrunRatio</c>, <c>u16 consecutiveOverrun</c>, <c>u16 consecutiveUnderrun</c>,
+    /// <c>u16 consecutiveQueueGrowth</c>, <c>i32 queueDepth</c>, <c>u8 level</c>, <c>u8 multiplier</c>.
+    /// </summary>
+    public static byte[] OverloadDetector(long timestamp, long tick, ushort consecutiveOverrun = 0, ushort consecutiveUnderrun = 0,
+        byte level = 0, byte tickMultiplier = 1, byte threadSlot = 0)
+    {
+        var record = new byte[CommonHeaderSize + 24];
+        WriteCommonHeader(record, (ushort)record.Length, TraceEventKind.SchedulerOverloadDetector, threadSlot, timestamp);
+        var p = record.AsSpan(CommonHeaderSize);
+        BinaryPrimitives.WriteInt64LittleEndian(p, tick);
+        BinaryPrimitives.WriteSingleLittleEndian(p[8..], 0f);
+        BinaryPrimitives.WriteUInt16LittleEndian(p[12..], consecutiveOverrun);
+        BinaryPrimitives.WriteUInt16LittleEndian(p[14..], consecutiveUnderrun);
+        BinaryPrimitives.WriteUInt16LittleEndian(p[16..], 0);
+        BinaryPrimitives.WriteInt32LittleEndian(p[18..], 0);
+        p[22] = level;
+        p[23] = tickMultiplier;
+        return record;
+    }
+
+    /// <summary>
+    /// <see cref="TraceEventKind.PerTickSnapshot"/> (76) — the gauge bundle. Delegates to the production
+    /// <see cref="PerTickSnapshotEventCodec"/> so the layout can never drift from the real one.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="engineTickNumber"/> is the record's embedded <b>absolute</b> tick number, the only absolute tick
+    /// number anywhere on the live wire. Tests use it both to drive the numbering offset and to detect a dropped
+    /// <c>TickStart</c>.
+    /// </remarks>
+    public static byte[] PerTickSnapshot(long timestamp, uint engineTickNumber, byte threadSlot = 0, IReadOnlyList<GaugeValue> gauges = null)
+    {
+        var values = gauges != null ? [.. gauges] : DefaultGauges();
+        var record = new byte[PerTickSnapshotEventCodec.ComputeSize(values)];
+        PerTickSnapshotEventCodec.WritePerTickSnapshot(record, threadSlot, timestamp, engineTickNumber, flags: 0, values, out _);
+        return record;
+    }
+
+    /// <summary><see cref="TraceEventKind.ThreadInfo"/> (77) — slot to name mapping. Uses the production codec.</summary>
+    public static byte[] ThreadInfo(long timestamp, byte threadSlot, int managedThreadId, string name, ThreadKind threadKind = ThreadKind.Worker)
+    {
+        var nameBytes = Encoding.UTF8.GetBytes(name ?? string.Empty);
+        var record = new byte[ThreadInfoEventCodec.ComputeSize(nameBytes.Length)];
+        ThreadInfoEventCodec.WriteThreadInfo(record, threadSlot, timestamp, managedThreadId, nameBytes, threadKind, out _);
+        return record;
+    }
+
+    /// <summary>
+    /// <see cref="TraceEventKind.SchedulerChunk"/> — a 47 B span, the highest-frequency detail record the profiler
+    /// emits and therefore the canonical "should be filtered" record in these tests. Payload after the span extension:
+    /// <c>u16 systemIndex</c>, <c>u16 chunkIndex</c>, <c>u16 totalChunks</c>, <c>i32 entitiesProcessed</c>.
+    /// </summary>
+    public static byte[] SchedulerChunk(long startTimestamp, long durationTicks, ushort systemIndex = 0, ushort chunkIndex = 0,
+        ushort totalChunks = 1, int entitiesProcessed = 1, byte threadSlot = 0)
+    {
+        var record = new byte[SpanPayloadOffset + 10];
+        WriteSpanHeader(record, (ushort)record.Length, TraceEventKind.SchedulerChunk, threadSlot, startTimestamp, durationTicks);
+        var p = record.AsSpan(SpanPayloadOffset);
+        BinaryPrimitives.WriteUInt16LittleEndian(p, systemIndex);
+        BinaryPrimitives.WriteUInt16LittleEndian(p[2..], chunkIndex);
+        BinaryPrimitives.WriteUInt16LittleEndian(p[4..], totalChunks);
+        BinaryPrimitives.WriteInt32LittleEndian(p[6..], entitiesProcessed);
+        return record;
+    }
+
+    /// <summary>
+    /// A generic span record of an arbitrary kind with an opaque zero payload. Lets a test assert that filtering is
+    /// driven by the exempt set rather than by any property of a specific detail kind.
+    /// </summary>
+    public static byte[] GenericSpan(TraceEventKind kind, long startTimestamp, long durationTicks, int payloadBytes = 4, byte threadSlot = 0)
+    {
+        if (payloadBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(payloadBytes), "payload size must be non-negative");
+        }
+        var record = new byte[SpanPayloadOffset + payloadBytes];
+        WriteSpanHeader(record, (ushort)record.Length, kind, threadSlot, startTimestamp, durationTicks);
+        return record;
+    }
+
+    /// <summary>Concatenate record byte arrays into one back-to-back buffer, the shape a Block frame carries.</summary>
+    public static byte[] Concat(params byte[][] records)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+        var total = 0;
+        foreach (var r in records)
+        {
+            total += r.Length;
+        }
+        var result = new byte[total];
+        var pos = 0;
+        foreach (var r in records)
+        {
+            r.CopyTo(result, pos);
+            pos += r.Length;
+        }
+        return result;
+    }
+
+    /// <summary>Count size-prefixed records in a packed buffer. Mirrors the builder's walk, including its bail-out rules.</summary>
+    public static int CountRecords(ReadOnlySpan<byte> records)
+    {
+        var count = 0;
+        var pos = 0;
+        while (pos + CommonHeaderSize <= records.Length)
+        {
+            var size = BinaryPrimitives.ReadUInt16LittleEndian(records[pos..]);
+            if (size < CommonHeaderSize || pos + size > records.Length)
+            {
+                break;
+            }
+            count++;
+            pos += size;
+        }
+        return count;
+    }
+
+    /// <summary>Enumerate the kinds present in a packed record buffer, in wire order.</summary>
+    public static List<TraceEventKind> KindsIn(ReadOnlySpan<byte> records)
+    {
+        var kinds = new List<TraceEventKind>();
+        var pos = 0;
+        while (pos + CommonHeaderSize <= records.Length)
+        {
+            var size = BinaryPrimitives.ReadUInt16LittleEndian(records[pos..]);
+            if (size < CommonHeaderSize || pos + size > records.Length)
+            {
+                break;
+            }
+            kinds.Add((TraceEventKind)records[pos + 2]);
+            pos += size;
+        }
+        return kinds;
+    }
+
+    private static GaugeValue[] DefaultGauges() =>
+    [
+        GaugeValue.FromU64(GaugeId.MemoryUnmanagedTotalBytes, 1024),
+        GaugeValue.FromU32(GaugeId.TxChainActiveCount, 2),
+    ];
+
+    private static void WriteCommonHeader(Span<byte> destination, ushort size, TraceEventKind kind, byte threadSlot, long timestamp)
+    {
+        BinaryPrimitives.WriteUInt16LittleEndian(destination, size);
+        destination[2] = (byte)kind;
+        destination[3] = threadSlot;
+        BinaryPrimitives.WriteInt64LittleEndian(destination[4..], timestamp);
+    }
+
+    private static void WriteSpanHeader(Span<byte> destination, ushort size, TraceEventKind kind, byte threadSlot, long startTimestamp, long durationTicks)
+    {
+        WriteCommonHeader(destination, size, kind, threadSlot, startTimestamp);
+        BinaryPrimitives.WriteInt64LittleEndian(destination[12..], durationTicks);
+        BinaryPrimitives.WriteUInt64LittleEndian(destination[20..], 0);   // spanId — unused by the builder paths under test
+        BinaryPrimitives.WriteUInt64LittleEndian(destination[28..], 0);   // parentSpanId
+        destination[36] = 0;                                              // spanFlags: trace-context bit clear
+    }
+}

--- a/tools/Typhon.Workbench.Fixtures/MockTcpProfilerServer.cs
+++ b/tools/Typhon.Workbench.Fixtures/MockTcpProfilerServer.cs
@@ -32,21 +32,71 @@ namespace Typhon.Workbench.Fixtures;
 /// Usage (Playwright via DEBUG-only <c>POST /api/fixtures/mock-profiler</c>): the Workbench holds a
 /// dictionary keyed by port and disposes each server on application shutdown.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Two modes.</b> The default <i>timer</i> mode preserves the original behaviour — after Init it emits
+/// <see cref="MaxBlocks"/> minimal tick blocks at <see cref="BlockInterval"/>. Setting <see cref="Scripted"/> before
+/// <see cref="Start"/> suppresses that loop entirely and hands control to the test, which pushes exactly the records it
+/// wants via <see cref="SendBlockAsync"/> and observes the effect deterministically. Filter tests need scripted mode:
+/// asserting "tick N carries detail and tick N+1 does not" is untestable against a timer.
+/// </para>
+/// <para>
+/// <b>Engine lifecycle simulation.</b> <see cref="SendShutdownAsync"/> models a clean quit (the engine's Shutdown
+/// envelope), <see cref="DropClientAsync"/> models a crash (socket closed with no warning). Both leave the listener up,
+/// so the Workbench's reconnect loop can land a fresh connection and receive a second Init — which is how restart
+/// behaviour is exercised without launching a process.
+/// </para>
+/// </remarks>
 public sealed class MockTcpProfilerServer : IAsyncDisposable
 {
     private readonly TcpListener _listener;
     private readonly CancellationTokenSource _cts = new();
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly object _clientLock = new();
+    private TaskCompletionSource _clientConnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private Task _acceptTask;
     private TcpClient _client;
     private bool _started;
+    private int _connectionCount;
 
     public int Port { get; private set; }
 
-    /// <summary>How often to emit Block frames after Init. Default 100 ms.</summary>
+    /// <summary>How often to emit Block frames after Init. Default 100 ms. Ignored when <see cref="Scripted"/> is set.</summary>
     public TimeSpan BlockInterval { get; set; } = TimeSpan.FromMilliseconds(100);
 
-    /// <summary>Maximum blocks to emit before idling. Defaults to 10 so tests don't run indefinitely.</summary>
+    /// <summary>Maximum blocks to emit before idling. Defaults to 10 so tests don't run indefinitely. Ignored when <see cref="Scripted"/> is set.</summary>
     public int MaxBlocks { get; set; } = 10;
+
+    /// <summary>
+    /// When true, no automatic Block emission happens — the test drives the stream via <see cref="SendBlockAsync"/>.
+    /// Must be set before <see cref="Start"/>.
+    /// </summary>
+    public bool Scripted { get; set; }
+
+    /// <summary>
+    /// Value written into the Init header's <c>CreatedUtcTicks</c>. Changing it between connections models a genuine
+    /// engine <b>restart</b>; leaving it constant models a transient socket drop within one engine process. The
+    /// Workbench distinguishes the two on exactly this field, so a fixture that cannot vary it cannot test either.
+    /// </summary>
+    public long CreatedUtcTicks { get; set; }
+
+    /// <summary>
+    /// Number of client connections accepted so far. A restart scenario expects this to reach 2: the original attach,
+    /// then the reconnect after <see cref="DropClientAsync"/> or <see cref="SendShutdownAsync"/>.
+    /// </summary>
+    public int ConnectionCount => Volatile.Read(ref _connectionCount);
+
+    /// <summary>True while a client socket is held open.</summary>
+    public bool HasClient
+    {
+        get
+        {
+            lock (_clientLock)
+            {
+                return _client != null;
+            }
+        }
+    }
 
     public MockTcpProfilerServer()
     {
@@ -62,38 +112,171 @@ public sealed class MockTcpProfilerServer : IAsyncDisposable
         _acceptTask = Task.Run(AcceptLoopAsync);
     }
 
+    /// <summary>
+    /// Completes once a client has connected and its Init frame has been written. Scripted tests await this before
+    /// pushing records, so a block can never race ahead of the handshake.
+    /// </summary>
+    public Task WaitForClientAsync(CancellationToken ct = default)
+    {
+        Task connected;
+        lock (_clientLock)
+        {
+            connected = _clientConnected.Task;
+        }
+        return connected.WaitAsync(ct);
+    }
+
     private async Task AcceptLoopAsync()
     {
-        try
+        while (!_cts.IsCancellationRequested)
         {
-            _client = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
-            _client.NoDelay = true;
-            var stream = _client.GetStream();
-
-            // Send Init frame immediately on connect.
-            var initPayload = BuildInitPayload();
-            await WriteFrameAsync(stream, LiveFrameType.Init, initPayload, _cts.Token).ConfigureAwait(false);
-
-            // Emit periodic Block frames. Each block carries one minimal TickStart + TickEnd record
-            // pair so the client's tick counter increments observably.
-            for (var i = 0; i < MaxBlocks && !_cts.IsCancellationRequested; i++)
+            TcpClient accepted;
+            try
             {
-                try
+                accepted = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (ObjectDisposedException) { break; }
+            catch (SocketException) { break; }
+
+            accepted.NoDelay = true;
+            lock (_clientLock)
+            {
+                _client = accepted;
+            }
+            Interlocked.Increment(ref _connectionCount);
+
+            try
+            {
+                var stream = accepted.GetStream();
+
+                // Send Init frame immediately on connect.
+                var initPayload = BuildInitPayload(CreatedUtcTicks);
+                await WriteFrameAsync(stream, LiveFrameType.Init, initPayload, _cts.Token).ConfigureAwait(false);
+
+                lock (_clientLock)
                 {
-                    await Task.Delay(BlockInterval, _cts.Token).ConfigureAwait(false);
+                    _clientConnected.TrySetResult();
                 }
-                catch (OperationCanceledException)
+
+                if (Scripted)
                 {
-                    break;
+                    // The test owns the stream from here. Park until the connection is torn down or the server stops.
+                    await WaitForDisconnectAsync(accepted).ConfigureAwait(false);
+                    continue;
                 }
-                var blockPayload = BuildBlockPayload(tickIndex: i + 1);
-                await WriteFrameAsync(stream, LiveFrameType.Block, blockPayload, _cts.Token).ConfigureAwait(false);
+
+                // Emit periodic Block frames. Each block carries one minimal TickStart + TickEnd record
+                // pair so the client's tick counter increments observably.
+                for (var i = 0; i < MaxBlocks && !_cts.IsCancellationRequested; i++)
+                {
+                    try
+                    {
+                        await Task.Delay(BlockInterval, _cts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    var blockPayload = BuildBlockPayload(tickIndex: i + 1);
+                    await WriteFrameAsync(stream, LiveFrameType.Block, blockPayload, _cts.Token).ConfigureAwait(false);
+                }
+
+                await WaitForDisconnectAsync(accepted).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { /* normal shutdown */ }
+            catch (ObjectDisposedException) { /* listener or client disposed */ }
+            catch (SocketException) { /* client disconnected */ }
+            catch (IOException) { /* client disconnected mid-send */ }
+        }
+    }
+
+    /// <summary>Parks until the connection drops or the server is cancelled, so the accept loop can take the next client.</summary>
+    private async Task WaitForDisconnectAsync(TcpClient client)
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            bool stillCurrent;
+            lock (_clientLock)
+            {
+                stillCurrent = ReferenceEquals(_client, client);
+            }
+            if (!stillCurrent || !client.Connected)
+            {
+                return;
+            }
+            try
+            {
+                await Task.Delay(20, _cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
             }
         }
-        catch (OperationCanceledException) { /* normal shutdown */ }
-        catch (ObjectDisposedException) { /* listener disposed */ }
-        catch (SocketException) { /* client disconnected */ }
-        catch (IOException) { /* client disconnected mid-send */ }
+    }
+
+    /// <summary>
+    /// Push one Block frame carrying <paramref name="records"/> — a packed, size-prefixed record buffer, typically built
+    /// with <see cref="MockRecordFactory"/>. The caller decides where block boundaries fall, which is what makes a
+    /// straddling-block test possible.
+    /// </summary>
+    public async Task SendBlockAsync(byte[] records, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+        var recordCount = MockRecordFactory.CountRecords(records);
+        var compressed = new byte[K4os.Compression.LZ4.LZ4Codec.MaximumOutputSize(Math.Max(records.Length, 1))];
+        var blockHeader = new byte[TraceBlockEncoder.BlockHeaderSize];
+        var compressedSize = TraceBlockEncoder.EncodeBlock(records, recordCount, compressed, blockHeader);
+
+        var payload = new byte[blockHeader.Length + compressedSize];
+        blockHeader.CopyTo(payload, 0);
+        Array.Copy(compressed, 0, payload, blockHeader.Length, compressedSize);
+
+        await SendFrameAsync(LiveFrameType.Block, payload, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Send the clean-quit <see cref="LiveFrameType.Shutdown"/> envelope, as a real engine does on orderly teardown.</summary>
+    public Task SendShutdownAsync(CancellationToken ct = default) => SendFrameAsync(LiveFrameType.Shutdown, [], ct);
+
+    /// <summary>
+    /// Close the client socket with no Shutdown envelope — the crash / kill path. The listener stays up, so the
+    /// Workbench's reconnect loop can land a new connection and receive a second Init.
+    /// </summary>
+    public Task DropClientAsync()
+    {
+        TcpClient toClose;
+        lock (_clientLock)
+        {
+            toClose = _client;
+            _client = null;
+            _clientConnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+        try { toClose?.Close(); } catch { /* already gone */ }
+        return Task.CompletedTask;
+    }
+
+    private async Task SendFrameAsync(LiveFrameType type, byte[] payload, CancellationToken ct)
+    {
+        TcpClient client;
+        lock (_clientLock)
+        {
+            client = _client;
+        }
+        if (client == null)
+        {
+            throw new InvalidOperationException("No client connected — await WaitForClientAsync() before sending.");
+        }
+
+        await _sendLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await WriteFrameAsync(client.GetStream(), type, payload, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
     }
 
     private static async Task WriteFrameAsync(NetworkStream stream, LiveFrameType type, byte[] payload, CancellationToken ct)
@@ -101,12 +284,15 @@ public sealed class MockTcpProfilerServer : IAsyncDisposable
         var header = new byte[LiveStreamProtocol.FrameHeaderSize];
         LiveStreamProtocol.WriteFrameHeader(header, type, payload.Length);
         await stream.WriteAsync(header, ct).ConfigureAwait(false);
-        await stream.WriteAsync(payload, ct).ConfigureAwait(false);
+        if (payload.Length > 0)
+        {
+            await stream.WriteAsync(payload, ct).ConfigureAwait(false);
+        }
         await stream.FlushAsync(ct).ConfigureAwait(false);
     }
 
     /// <summary>Minimal Init payload: header + empty system / archetype / component-type tables.</summary>
-    private static byte[] BuildInitPayload()
+    private static byte[] BuildInitPayload(long createdUtcTicks)
     {
         using var ms = new MemoryStream();
         var header = new TraceFileHeader
@@ -120,7 +306,7 @@ public sealed class MockTcpProfilerServer : IAsyncDisposable
             SystemCount = 0,
             ArchetypeCount = 0,
             ComponentTypeCount = 0,
-            CreatedUtcTicks = 0,
+            CreatedUtcTicks = createdUtcTicks,
             SamplingSessionStartQpc = 0,
         };
         ms.Write(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(in header, 1)));
@@ -192,13 +378,18 @@ public sealed class MockTcpProfilerServer : IAsyncDisposable
         {
             _cts.Cancel();
         }
-        try { _client?.Close(); } catch { /* ignore */ }
+        lock (_clientLock)
+        {
+            try { _client?.Close(); } catch { /* ignore */ }
+            _client = null;
+        }
         try { _listener.Stop(); } catch { /* ignore */ }
         if (_acceptTask != null)
         {
             try { await _acceptTask.ConfigureAwait(false); }
             catch { /* already observed */ }
         }
+        _sendLock.Dispose();
         _cts.Dispose();
     }
 }

--- a/tools/Typhon.Workbench/ClientApp/schema/openapi.json
+++ b/tools/Typhon.Workbench/ClientApp/schema/openapi.json
@@ -5067,6 +5067,9 @@
               "null",
               "string"
             ]
+          },
+          "cherryPick": {
+            "type": "boolean"
           }
         }
       },
@@ -9004,6 +9007,16 @@
               "string"
             ],
             "format": "uuid"
+          },
+          "profilerEndpoint": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "isWatchingLive": {
+            "type": "boolean",
+            "default": false
           }
         }
       },

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/profiler/useProfilerLiveStream.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/profiler/useProfilerLiveStream.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useEventSource } from '@/hooks/streams/useEventSource';
 import {
   useProfilerSessionStore,
+  type CaptureState,
   type ConnectionStatus,
   type LiveStreamPayload,
   type LiveThreadInfo,
@@ -68,6 +69,8 @@ export function useProfilerLiveStream(sessionId: string | null) {
         enqueue({ kind: 'threadInfoAdded', threadInfo: data.threadInfo }),
       globalMetricsUpdated: (data: { globalMetrics: GlobalMetricsDto }) =>
         enqueue({ kind: 'globalMetricsUpdated', globalMetrics: data.globalMetrics }),
+      captureStateChanged: (data: { captureState: CaptureState }) =>
+        enqueue({ kind: 'captureStateChanged', captureState: data.captureState }),
       heartbeat: (data: { status: ConnectionStatus }) => enqueue({ kind: 'heartbeat', status: data.status }),
       shutdown: (data: { status: string }) => enqueue({ kind: 'shutdown', status: data.status ?? 'disconnected' }),
     }),

--- a/tools/Typhon.Workbench/ClientApp/src/libs/profiler/canvas/__tests__/recordedTicksOnly.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/profiler/canvas/__tests__/recordedTicksOnly.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BAR_LEFT_PAD,
+  BAR_WIDTH,
+  GAP_BAND_WIDTH,
+  barsThatFit,
+  buildTickRows,
+  computeBarOffsets,
+  hitTestTick,
+  isRecordedTick,
+  missingTicksBefore,
+  recordedTicksOnly,
+  type TickSummaryLike,
+} from '../tickOverview';
+
+/**
+ * #805 — the overview must draw only the ticks a cherry-pick capture actually recorded.
+ *
+ * A skipped tick still produces a summary: the capture filter forwards a per-tick skeleton (TickStart/TickEnd, the
+ * metronome wait, the overload counters, the gauge snapshot) so tick numbering stays absolute across the windows the
+ * operator never armed. Those summaries carry no system activity, so a bar drawn for one is a bar you can click to
+ * see nothing.
+ */
+function tick(over: Partial<TickSummaryLike> & { tickNumber: number }): TickSummaryLike {
+  return {
+    startUs: 0,
+    durationUs: 1000,
+    eventCount: 5,
+    activeSystemsBitmask: '0',
+    maxSystemDurationUs: 0,
+    ...over,
+  } as TickSummaryLike;
+}
+
+describe('isRecordedTick', () => {
+  it('rejects a skeleton tick — no systems ran', () => {
+    expect(isRecordedTick(tick({ tickNumber: 512 }))).toBe(false);
+  });
+
+  it('accepts a tick with an active-systems bitmask', () => {
+    expect(isRecordedTick(tick({ tickNumber: 512, activeSystemsBitmask: '6' }))).toBe(true);
+  });
+
+  it('accepts a tick whose systems ran but sit past bit 63 — bitmask 0, duration > 0', () => {
+    // The builder only ORs system indices below 64, so a wider DAG reports 0 for a tick that genuinely ran.
+    expect(isRecordedTick(tick({ tickNumber: 512, activeSystemsBitmask: '0', maxSystemDurationUs: 42 }))).toBe(true);
+  });
+
+  it('does not special-case tick 0 — whether the pre-tick window is worth showing depends on its neighbour', () => {
+    expect(isRecordedTick(tick({ tickNumber: 0, eventCount: 200_000 }))).toBe(false);
+  });
+
+  it('keeps a summary that carries neither field — absence of evidence must not blank the strip', () => {
+    const minimal = { tickNumber: 7, startUs: 0, durationUs: 10, eventCount: 3 } as TickSummaryLike;
+    expect(isRecordedTick(minimal)).toBe(true);
+  });
+
+  it('treats a null bitmask as no information rather than as zero', () => {
+    const s = { tickNumber: 7, startUs: 0, durationUs: 10, eventCount: 3, activeSystemsBitmask: null } as TickSummaryLike;
+    expect(isRecordedTick(s)).toBe(true);
+  });
+
+  it('does not lose a huge u64 bitmask to float precision', () => {
+    expect(isRecordedTick(tick({ tickNumber: 9, activeSystemsBitmask: '18446744073709551615' }))).toBe(true);
+  });
+});
+
+describe('recordedTicksOnly', () => {
+  it('keeps two armed windows and drops the skeleton between them', () => {
+    const summaries: TickSummaryLike[] = [
+      tick({ tickNumber: 100, activeSystemsBitmask: '3' }),
+      tick({ tickNumber: 101, activeSystemsBitmask: '3' }),
+      tick({ tickNumber: 102 }),
+      tick({ tickNumber: 103 }),
+      tick({ tickNumber: 104 }),
+      tick({ tickNumber: 105, activeSystemsBitmask: '3' }),
+    ];
+
+    const kept = recordedTicksOnly(summaries);
+    expect(kept?.map((s) => Number(s.tickNumber))).toEqual([100, 101, 105]);
+  });
+
+  it('keeps the pre-tick window when the run starts at tick 1 — it abuts what is shown', () => {
+    const summaries: TickSummaryLike[] = [
+      tick({ tickNumber: 0, eventCount: 200_000 }),
+      tick({ tickNumber: 1, activeSystemsBitmask: '3' }),
+      tick({ tickNumber: 2, activeSystemsBitmask: '3' }),
+    ];
+
+    expect(recordedTicksOnly(summaries)?.map((s) => Number(s.tickNumber))).toEqual([0, 1, 2]);
+  });
+
+  /**
+   * The reported case: a cherry-picked window recorded from tick 133. The tick-0 stub is not the setup window for
+   * anything on screen, and keeping it drags a 132-tick separator onto the strip beside it.
+   */
+  it('drops the pre-tick window when the recording starts far later', () => {
+    const summaries: TickSummaryLike[] = [
+      tick({ tickNumber: 0, eventCount: 12 }),
+      tick({ tickNumber: 133, activeSystemsBitmask: '3' }),
+      tick({ tickNumber: 134, activeSystemsBitmask: '3' }),
+    ];
+
+    const kept = recordedTicksOnly(summaries);
+    expect(kept?.map((s) => Number(s.tickNumber))).toEqual([133, 134]);
+    // And with tick 0 gone there is no jump at the head of the strip, so no separator is drawn before the first bar.
+    expect(missingTicksBefore(buildTickRows(kept), 1)).toBe(0);
+  });
+
+  it('keeps a tick 0 that genuinely ran systems, wherever it sits', () => {
+    const summaries: TickSummaryLike[] = [
+      tick({ tickNumber: 0, activeSystemsBitmask: '3' }),
+      tick({ tickNumber: 133, activeSystemsBitmask: '3' }),
+    ];
+
+    expect(recordedTicksOnly(summaries)?.map((s) => Number(s.tickNumber))).toEqual([0, 133]);
+  });
+
+  it('returns the SAME array when nothing is filtered, so useMemo consumers keep referential identity', () => {
+    const summaries: TickSummaryLike[] = [
+      tick({ tickNumber: 1, activeSystemsBitmask: '1' }),
+      tick({ tickNumber: 2, activeSystemsBitmask: '1' }),
+    ];
+    expect(recordedTicksOnly(summaries)).toBe(summaries);
+  });
+
+  it('passes null and empty through unchanged', () => {
+    expect(recordedTicksOnly(null)).toBeNull();
+    expect(recordedTicksOnly(undefined)).toBeUndefined();
+    expect(recordedTicksOnly([])).toEqual([]);
+  });
+});
+
+describe('missingTicksBefore — the discontinuity marker', () => {
+  const rows = buildTickRows([
+    tick({ tickNumber: 1, startUs: 0, activeSystemsBitmask: '1' }),
+    tick({ tickNumber: 2, startUs: 1000, activeSystemsBitmask: '1' }),
+    tick({ tickNumber: 4, startUs: 2000, activeSystemsBitmask: '1' }),
+    tick({ tickNumber: 8, startUs: 3000, activeSystemsBitmask: '1' }),
+  ]);
+
+  it('reports no gap for consecutive ticks', () => {
+    expect(missingTicksBefore(rows, 1)).toBe(0);
+  });
+
+  it('counts a single skipped tick', () => {
+    expect(missingTicksBefore(rows, 2)).toBe(1); // 2 → 4 skips tick 3
+  });
+
+  it('counts a multi-tick gap', () => {
+    expect(missingTicksBefore(rows, 3)).toBe(3); // 4 → 8 skips 5, 6, 7
+  });
+
+  it('reports nothing before the first bar — there is no earlier tick to jump from', () => {
+    expect(missingTicksBefore(rows, 0)).toBe(0);
+  });
+
+  it('is bounds-safe past the end', () => {
+    expect(missingTicksBefore(rows, 99)).toBe(0);
+  });
+
+  it('never invents a gap from a non-ascending list', () => {
+    const descending = buildTickRows([
+      tick({ tickNumber: 9, startUs: 0, activeSystemsBitmask: '1' }),
+      tick({ tickNumber: 4, startUs: 1000, activeSystemsBitmask: '1' }),
+    ]);
+    expect(missingTicksBefore(descending, 1)).toBe(0);
+  });
+});
+
+describe('computeBarOffsets / hitTestTick — the band takes real space', () => {
+  // Ticks 1,2,4,8 → bands before the 3rd bar (2→4) and the 4th (4→8).
+  const rows = buildTickRows([
+    tick({ tickNumber: 1, startUs: 0, activeSystemsBitmask: '1' }),
+    tick({ tickNumber: 2, startUs: 1000, activeSystemsBitmask: '1' }),
+    tick({ tickNumber: 4, startUs: 2000, activeSystemsBitmask: '1' }),
+    tick({ tickNumber: 8, startUs: 3000, activeSystemsBitmask: '1' }),
+  ]);
+
+  it('inserts a band width before each discontinuity, shifting the following bars', () => {
+    expect(computeBarOffsets(rows, 0, 4)).toEqual([
+      0,
+      BAR_WIDTH,
+      BAR_WIDTH * 2 + GAP_BAND_WIDTH,
+      BAR_WIDTH * 3 + GAP_BAND_WIDTH * 2,
+    ]);
+  });
+
+  it('reserves no band before the first visible bar — there is no visible neighbour to separate', () => {
+    // Window starts ON the discontinuity at index 2; it must not be pushed right by a band with nothing to its left.
+    expect(computeBarOffsets(rows, 2, 4)).toEqual([0, BAR_WIDTH + GAP_BAND_WIDTH]);
+  });
+
+  it('hit-tests bars through the shifted layout', () => {
+    const offsets = computeBarOffsets(rows, 0, 4);
+    const at = (x: number) => hitTestTick(BAR_LEFT_PAD + x, 500, { startIdx: 0, endIdx: 4 }, offsets);
+
+    expect(at(0)).toBe(0);
+    expect(at(BAR_WIDTH + 1)).toBe(1);
+    // Without the offset table this x divides to bar 2 and would select the wrong tick — silently, because the
+    // wrong tick is a perfectly plausible one.
+    expect(at(BAR_WIDTH * 2 + GAP_BAND_WIDTH + 1)).toBe(2);
+    expect(at(BAR_WIDTH * 3 + GAP_BAND_WIDTH * 2 + 1)).toBe(3);
+  });
+
+  it('returns -1 inside a band — there is no tick there', () => {
+    const offsets = computeBarOffsets(rows, 0, 4);
+    const insideBand = BAR_WIDTH * 2 + 2; // between bar 1's end and bar 2's start
+    expect(hitTestTick(BAR_LEFT_PAD + insideBand, 500, { startIdx: 0, endIdx: 4 }, offsets)).toBe(-1);
+  });
+
+  it('returns -1 past the last bar', () => {
+    const offsets = computeBarOffsets(rows, 0, 4);
+    const past = BAR_WIDTH * 4 + GAP_BAND_WIDTH * 2 + 1;
+    expect(hitTestTick(BAR_LEFT_PAD + past, 500, { startIdx: 0, endIdx: 4 }, offsets)).toBe(-1);
+  });
+});
+
+describe('barsThatFit', () => {
+  const rows = buildTickRows([
+    tick({ tickNumber: 1, startUs: 0, activeSystemsBitmask: '1' }),
+    tick({ tickNumber: 2, startUs: 1000, activeSystemsBitmask: '1' }),
+    tick({ tickNumber: 9, startUs: 2000, activeSystemsBitmask: '1' }),
+  ]);
+
+  it('counts the bands against the budget, so bars are not clipped off the right edge', () => {
+    // Two bars fit in 2×BAR_WIDTH. The third needs a band as well, so it needs BAR_WIDTH + GAP_BAND_WIDTH more.
+    expect(barsThatFit(rows, 0, BAR_WIDTH * 2)).toBe(2);
+    expect(barsThatFit(rows, 0, BAR_WIDTH * 3)).toBe(2);
+    expect(barsThatFit(rows, 0, BAR_WIDTH * 3 + GAP_BAND_WIDTH)).toBe(3);
+  });
+
+  it('never reports more bars than exist, and none for no space', () => {
+    expect(barsThatFit(rows, 0, 10_000)).toBe(3);
+    expect(barsThatFit(rows, 0, 0)).toBe(0);
+  });
+});
+
+describe('buildTickRows over a filtered list', () => {
+  /**
+   * `buildTickRows` clamps each bar's end to the NEXT summary's start to absorb wire float drift. Across a gap between
+   * two armed windows that next start is far away, so the clamp must not apply — a bar has to keep its own duration
+   * rather than stretch across the ticks that were skipped.
+   */
+  it('does not stretch a bar across the gap left by skipped ticks', () => {
+    const summaries: TickSummaryLike[] = [
+      tick({ tickNumber: 100, startUs: 0, durationUs: 100, activeSystemsBitmask: '3' }),
+      tick({ tickNumber: 900, startUs: 1_000_000, durationUs: 100, activeSystemsBitmask: '3' }),
+    ];
+
+    const rows = buildTickRows(recordedTicksOnly(summaries));
+    expect(rows).toHaveLength(2);
+    expect(rows[0].endUs).toBe(100);
+    expect(rows[1].startUs).toBe(1_000_000);
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/libs/profiler/canvas/tickOverview.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/profiler/canvas/tickOverview.ts
@@ -42,6 +42,10 @@ export interface TickSummaryLike {
   tickNumber: number | string;
   startUs: number | string;
   durationUs: number | string;
+  /** u64-as-string bitmask of the systems that ran this tick. Absent on minimal callers; `0`/null on a tick with none. */
+  activeSystemsBitmask?: string | number | null;
+  /** Longest single system execution this tick. `0` when no system-scoped record was retained. */
+  maxSystemDurationUs?: number | string;
   eventCount: number | string;
   // v9+ integer fields. Orval's .NET-OpenAPI codegen emits these as `number | string` (precision-preserving
   // dual representation, same as `tickNumber` / `eventCount` above), so the Like shape accepts both — consumers
@@ -68,6 +72,135 @@ export interface TickSummaryLike {
  * Real engine-idle gaps (next.startUs greater than start + duration) are preserved — the clamp uses
  * `Math.min`, so it only trims overshoot, never extends.
  */
+/**
+ * Does this tick carry anything to look at?
+ *
+ * On-demand tick capture (#805) keeps a per-tick SKELETON for every tick — `TickStart`/`TickEnd`, the metronome wait,
+ * the overload counters, the gauge snapshot — so tick numbering stays absolute across windows the operator never armed.
+ * Those ticks still finalize into summaries, so without this predicate the overview draws a bar per engine tick and a
+ * hundred recorded ticks are lost in thousands of empty ones. Clicking such a bar selects a tick with no systems, no
+ * spans and nothing in the detail panel.
+ *
+ * <p><b>Only the timeline filters.</b> Engine Live Health reads the same summaries for tick rate, gauges and anomalies
+ * and must keep seeing every tick — that panel is what you watch while deciding when to press Record.</p>
+ *
+ * <b>Summaries carrying neither field</b> deliberately survive: a caller that supplies only the core four cannot be
+ * judged, and guessing "not recorded" would blank the strip entirely. Absence of evidence is not evidence of absence.
+ *
+ * The synthetic pre-tick summary (tick 0) is <i>not</i> special-cased here — it has no systems by construction, so it
+ * fails this test. {@link recordedTicksOnly} decides its fate, because whether it is worth showing depends on its
+ * neighbour rather than on itself.
+ */
+export function isRecordedTick(s: TickSummaryLike): boolean {
+  const bitmask = s.activeSystemsBitmask;
+  const hasBitmask = bitmask !== undefined && bitmask !== null;
+  const hasMaxDuration = s.maxSystemDurationUs !== undefined;
+  if (!hasBitmask && !hasMaxDuration) return true;
+
+  // Number() on a u64 beyond 2^53 loses precision, but never turns a non-zero value into zero — and zero is the only
+  // thing being tested. Both fields are consulted because the bitmask only tracks system indices below 64, so a DAG
+  // wider than that would report 0 for a tick whose systems genuinely ran.
+  if (hasBitmask && Number(bitmask) !== 0) return true;
+  return hasMaxDuration && Number(s.maxSystemDurationUs) > 0;
+}
+
+/**
+ * How many tick numbers are missing immediately before `index`, or 0 when the axis is continuous there.
+ *
+ * Cherry-picked capture makes the tick axis **discontinuous**: recording ticks 1–4 and then 8–10 leaves the overview
+ * drawing seven bars whose numbers jump 4 → 8. Without a marker those bars read as one uninterrupted run, so a spike
+ * at tick 8 looks like it happened right after tick 4 — the strip would be quietly lying about time.
+ *
+ * Returns a count rather than a boolean because the size of the gap is what the reader wants: "3 ticks skipped" and
+ * "4,000 ticks skipped" are the same picture but very different runs.
+ */
+export function missingTicksBefore(ticks: readonly TickRow[], index: number): number {
+  if (index <= 0 || index >= ticks.length) return 0;
+  const gap = ticks[index].tickNumber - ticks[index - 1].tickNumber - 1;
+  // Negative would mean the list is not ascending — never true for summaries, and reporting a "gap" for it would be
+  // an invention. Zero is the honest answer for anything that is not a forward jump.
+  return gap > 0 ? gap : 0;
+}
+
+/** Width of the hatched band inserted where the tick axis jumps. */
+export const GAP_BAND_WIDTH = 6;
+
+/**
+ * X offset of each visible bar, relative to {@link BAR_LEFT_PAD}, with a {@link GAP_BAND_WIDTH} slot **inserted**
+ * wherever the tick axis jumps.
+ *
+ * The band occupies real space rather than overpainting the bars either side of it. Overpainting was the first
+ * attempt and it is wrong twice over: it mutilates two bars that carry data, and it still presents them as adjacent
+ * — the reader sees one continuous run with a mark drawn on it, instead of a run that visibly stops and restarts.
+ *
+ * Returned as a table because every consumer needs the same arithmetic — bars, GC markers, the selection overlay,
+ * tick labels, the hover outline and hit-testing. Nine sites computing `(i - startIdx) * BAR_WIDTH` independently is
+ * exactly how a strip ends up where the bar you click is not the bar you hit.
+ */
+export function computeBarOffsets(
+  ticks: readonly TickRow[],
+  startIdx: number,
+  endIdx: number,
+): number[] {
+  const count = Math.max(0, endIdx - startIdx);
+  const offsets = new Array<number>(count);
+  let x = 0;
+  for (let k = 0; k < count; k++) {
+    // No band before the first visible bar: there is no visible left-hand neighbour for it to separate. The break is
+    // still real, but it is off-screen, and a leading band would only push the strip right for no reader benefit.
+    if (k > 0 && missingTicksBefore(ticks, startIdx + k) > 0) {
+      x += GAP_BAND_WIDTH;
+    }
+    offsets[k] = x;
+    x += BAR_WIDTH;
+  }
+  return offsets;
+}
+
+/**
+ * How many bars fit in `availablePx`, counting the gap bands that have to be inserted among them.
+ *
+ * Sizing the window as `availablePx / BAR_WIDTH` ignores that space and overflows the canvas by exactly the total
+ * band width — the right-hand bars would be drawn past the edge and silently clipped.
+ */
+export function barsThatFit(ticks: readonly TickRow[], startIdx: number, availablePx: number): number {
+  if (availablePx <= 0) return 0;
+  let used = 0;
+  let fitted = 0;
+  for (let k = 0; startIdx + k < ticks.length; k++) {
+    const band = k > 0 && missingTicksBefore(ticks, startIdx + k) > 0 ? GAP_BAND_WIDTH : 0;
+    if (used + band + BAR_WIDTH > availablePx) break;
+    used += band + BAR_WIDTH;
+    fitted++;
+  }
+  return fitted;
+}
+
+/**
+ * The overview's input: the recorded ticks, in order. Returns the original array untouched when nothing is filtered,
+ * so the common case (a trace, or an attach recording everything) keeps referential identity for `useMemo`.
+ */
+export function recordedTicksOnly<T extends TickSummaryLike>(
+  summaries: readonly T[] | null | undefined,
+): readonly T[] | null | undefined {
+  if (!summaries || summaries.length === 0) return summaries;
+  const kept = summaries.filter(isRecordedTick);
+
+  // The synthetic tick 0 — the pre-tick engine-setup window — is worth a bar only when it ABUTS the run being shown,
+  // i.e. the recording starts at tick 1. Then it is the "before the loop started" slot the user clicks to reach setup
+  // events, and it sits flush against tick 1 with no discontinuity.
+  //
+  // In a cherry-picked capture it usually does not abut anything: record a window at tick 133 and you get a stub
+  // holding whatever arrived before the first TickStart, followed by a 132-tick gap. That bar is not the setup window
+  // for anything on screen — it is a fragment with a separator after it, and both are noise.
+  const first = summaries[0];
+  if (first && Number(first.tickNumber) === 0 && !isRecordedTick(first) && kept.length > 0 && Number(kept[0].tickNumber) === 1) {
+    kept.unshift(first);
+  }
+
+  return kept.length === summaries.length ? summaries : kept;
+}
+
 export function buildTickRows(summaries: readonly TickSummaryLike[] | null | undefined): TickRow[] {
   if (!summaries || summaries.length === 0) return [];
   const result: TickRow[] = new Array(summaries.length);
@@ -233,6 +366,10 @@ export function drawTickOverview(
   ctx.setLineDash([]);
 
   const barWidth = BAR_WIDTH;
+  // Every x in this function comes from here, so bars, markers, overlay, labels and hit-testing cannot drift apart
+  // once discontinuity bands start consuming horizontal space.
+  const barOffsets = computeBarOffsets(ticks, sr.startIdx, sr.endIdx);
+  const barX = (index: number) => BAR_LEFT_PAD + barOffsets[index - sr.startIdx];
 
   // Bars. Minimum 1 px height floor so very-short ticks (e.g. a fast ForceCheckpoint) stay visible.
   // A second pass below draws the GC marker triangles so they overlay the bars without being clipped by
@@ -241,7 +378,7 @@ export function drawTickOverview(
     const tick = ticks[i];
     const ratio = Math.min(tick.durationUs / p95, 1.0);
     const barH = Math.max(1, ratio * barAreaHeight);
-    const x = BAR_LEFT_PAD + (i - sr.startIdx) * barWidth;
+    const x = barX(i);
     const y = barAreaTop + barAreaHeight - barH;
 
     // Throttle tint takes priority over P95 colouring — a tick where the engine has slowed itself is
@@ -269,7 +406,7 @@ export function drawTickOverview(
     for (let i = sr.startIdx; i < sr.endIdx; i++) {
       const tick = ticks[i];
       if (!gcTicks.has(tick.tickNumber)) continue;
-      const x = BAR_LEFT_PAD + (i - sr.startIdx) * barWidth;
+      const x = barX(i);
       const cx = x + Math.floor((barWidth - 1) / 2);
       ctx.beginPath();
       ctx.moveTo(cx, baseY - height);
@@ -281,13 +418,62 @@ export function drawTickOverview(
     }
   }
 
+  // Discontinuity markers — where the tick axis jumps.
+  //
+  // Drawn in the 1-px lane the bar pass already leaves between bars, so the layout, hit-testing and every index
+  // calculation downstream are untouched: this is annotation, not spacing. A cherry-picked capture holds ticks 1–4 and
+  // 8–10 side by side, and without this the strip presents them as one continuous run — the reader would measure a
+  // spike at tick 8 as following immediately from tick 4.
+  //
+  // A hatched band rather than a line: diagonal stripes are the conventional "axis break" mark, and they cannot be
+  // mistaken for data the way a vertical rule sitting among vertical bars can. The band is cleared to the strip
+  // background first, so it reads as a CUT through the strip instead of an overlay on top of it.
+  {
+    const gapTop = barAreaTop;
+    const gapBottom = barAreaTop + barAreaHeight;
+    // The band sits in space `computeBarOffsets` already reserved for it — the bar to its right was pushed along by
+    // exactly this width — so it covers no data at all. Starting at startIdx + 1 matches that layout: no space is
+    // reserved before the first visible bar, and a band drawn there would sit on top of it.
+    // One pixel narrower than the slot, matching the `barWidth - 1` convention the bar pass uses: the bar to the LEFT
+    // already ends one pixel short, so painting the full slot would leave the band flush against the right-hand bar and
+    // separated from the left one. Inset keeps a lane on both sides and the band visually centred in its own space.
+    const bandWidth = GAP_BAND_WIDTH - 1;
+    for (let i = sr.startIdx + 1; i < sr.endIdx; i++) {
+      if (missingTicksBefore(ticks, i) <= 0) continue;
+      const x0 = barX(i) - GAP_BAND_WIDTH;
+
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(x0, gapTop, bandWidth, gapBottom - gapTop);
+      ctx.clip();
+
+      ctx.fillStyle = theme.card;
+      ctx.fillRect(x0, gapTop, bandWidth, gapBottom - gapTop);
+
+      // Mid-grey: it reads on both themes without claiming severity. A break in the axis is a fact about the recording,
+      // not a problem with the run — amber sat in the same register as the throttle tints and the GC marker, which are
+      // warnings.
+      ctx.strokeStyle = '#8A8A8A';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      // 45° stripes. The loop starts a band-width above the top and ends one below the bottom so the diagonals reach
+      // the corners — stopping at the exact bounds leaves untouched triangles at each end.
+      for (let y = gapTop - bandWidth; y <= gapBottom + bandWidth; y += 3) {
+        ctx.moveTo(x0, y + bandWidth);
+        ctx.lineTo(x0 + bandWidth, y);
+      }
+      ctx.stroke();
+      ctx.restore();
+    }
+  }
+
   // Green selection overlay — ticks overlapping viewRange.
   if (selection.first >= 0) {
     const drawFirst = Math.max(selection.first, sr.startIdx);
     const drawLast = Math.min(selection.last, sr.endIdx - 1);
     if (drawFirst <= drawLast) {
-      const overlayStartX = BAR_LEFT_PAD + (drawFirst - sr.startIdx) * barWidth;
-      const overlayEndX = BAR_LEFT_PAD + (drawLast - sr.startIdx + 1) * barWidth;
+      const overlayStartX = barX(drawFirst);
+      const overlayEndX = barX(drawLast) + barWidth;
       ctx.fillStyle = OVERLAY_COLOR;
       ctx.fillRect(overlayStartX, barAreaTop, overlayEndX - overlayStartX, barAreaHeight);
       ctx.strokeStyle = OVERLAY_BORDER;
@@ -336,7 +522,7 @@ export function drawTickOverview(
   ctx.textAlign = 'center';
   const labelEvery = Math.max(1, Math.floor(60 / barWidth));
   for (let i = sr.startIdx; i < sr.endIdx; i += labelEvery) {
-    const x = BAR_LEFT_PAD + (i - sr.startIdx) * barWidth + barWidth / 2;
+    const x = barX(i) + barWidth / 2;
     ctx.fillText(`${ticks[i].tickNumber}`, x, height - 5);
   }
 
@@ -347,8 +533,8 @@ export function drawTickOverview(
     const clampedA = Math.max(sr.startIdx, a);
     const clampedB = Math.min(sr.endIdx - 1, b);
     if (clampedA <= clampedB) {
-      const x1 = BAR_LEFT_PAD + (clampedA - sr.startIdx) * barWidth;
-      const x2 = BAR_LEFT_PAD + (clampedB - sr.startIdx + 1) * barWidth;
+      const x1 = barX(clampedA);
+      const x2 = barX(clampedB) + barWidth;
       ctx.fillStyle = OVERVIEW_PALETTE.selection + '30';
       ctx.fillRect(x1, barAreaTop, x2 - x1, barAreaHeight);
       ctx.strokeStyle = OVERLAY_BORDER;
@@ -402,7 +588,7 @@ export function drawTickOverview(
   // wrapper (see TickOverview.tsx) so it doesn't obstruct adjacent bars in the strip. The canvas
   // draw pass only highlights the hovered bar; content goes through HelpOverlay.
   if (!helpHovered && hover && hover.tickIdx >= sr.startIdx && hover.tickIdx < sr.endIdx) {
-    const x = BAR_LEFT_PAD + (hover.tickIdx - sr.startIdx) * barWidth;
+    const x = barX(hover.tickIdx);
     // Primary accent — chromatic outline that reads as "this is hovered" in both themes without feeling as
     // heavy as a jet-black foreground stroke does against a pale card in light mode.
     ctx.strokeStyle = theme.primary;
@@ -484,19 +670,33 @@ export function hitTestScrollbar(
 
 /**
  * Translate an in-canvas mouse X to the tick index under it (within the current visible window), or `-1`.
- * Bar width is the fixed <see cref="BAR_WIDTH"/>. <c>canvasWidth</c> kept in the signature for symmetry with
- * <see cref="hitTestScrollbar"/> even though it isn't read — callers always pass it.
+ *
+ * Reads the same offset table the draw pass uses, because bars are no longer on a uniform pitch: a discontinuity band
+ * consumes {@link GAP_BAND_WIDTH} of horizontal space, so `floor(x / BAR_WIDTH)` drifts by one bar per band and every
+ * click past the first gap would select the wrong tick — silently, since the wrong tick is a perfectly plausible one.
+ *
+ * A click that lands **inside** a band returns `-1`: there is no tick there. That is the honest answer, and it stops a
+ * click in the gap from snapping the viewport to a neighbour the user did not aim at.
  */
 export function hitTestTick(
   mouseX: number,
   _canvasWidth: number,
   scrollWindow: { startIdx: number; endIdx: number },
+  barOffsets: readonly number[],
 ): number {
-  const visibleCount = scrollWindow.endIdx - scrollWindow.startIdx;
+  const visibleCount = Math.min(scrollWindow.endIdx - scrollWindow.startIdx, barOffsets.length);
   if (visibleCount <= 0) return -1;
   const offsetMouseX = mouseX - BAR_LEFT_PAD;
-  if (offsetMouseX < 0 || offsetMouseX >= visibleCount * BAR_WIDTH) return -1;
-  return scrollWindow.startIdx + Math.floor(offsetMouseX / BAR_WIDTH);
+  if (offsetMouseX < 0) return -1;
+
+  // Offsets ascend, so the last bar starting at or before the cursor is the only candidate; anything beyond its width
+  // is either a band (bands precede the bar that follows them) or past the end of the strip.
+  for (let k = visibleCount - 1; k >= 0; k--) {
+    const start = barOffsets[k];
+    if (offsetMouseX < start) continue;
+    return offsetMouseX < start + BAR_WIDTH ? scrollWindow.startIdx + k : -1;
+  }
+  return -1;
 }
 
 /**

--- a/tools/Typhon.Workbench/ClientApp/src/panels/EngineLiveHealth/EngineLiveHealthPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/EngineLiveHealth/EngineLiveHealthPanel.tsx
@@ -91,9 +91,12 @@ export default function EngineLiveHealthPanel(_props: IDockviewPanelProps) {
     setCaptureError(null);
     try {
       await captureAndAnalyse(sessionId);
-      // On success the session kind transitions; the panel unmounts and there's nothing to clean up here.
     } catch (e) {
       setCaptureError((e as Error)?.message ?? 'Capture & Analyse failed.');
+    } finally {
+      // This used to clear only on the failure arm, because success transitioned the session to a 'trace' session and
+      // unmounted the panel. #613 deleted that kind and #621 attaches the replay to THIS session instead, so the panel
+      // survives its own success — and the button stayed on 'Capturing…' for ever with the file already on disk.
       setIsCapturing(false);
     }
   }

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/ProfilerPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/ProfilerPanel.tsx
@@ -2,12 +2,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { IDockviewPanelProps } from 'dockview-react';
 import { Activity, AlertCircle, Loader2, Radio, RefreshCw, Unplug } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import CaptureControl from '@/panels/profiler/components/CaptureControl';
 import { usePanelHotkeys } from '@/hooks/usePanelHotkeys';
 import { getApiSessionsId } from '@/api/generated/sessions/sessions';
 import { captureFileName } from '@/libs/profiles/captureLocation';
 import { useDeleteApiSessionsSessionIdProfileProfileId, usePostApiSessionsSessionIdProfile } from '@/api/generated/profiles/profiles';
 import { logError, logInfo } from '@/stores/useLogStore';
-import { useSessionStore, useTraceBackedSession } from '@/stores/useSessionStore';
+import { useLiveStreamSession, useSessionStore, useTraceBackedSession } from '@/stores/useSessionStore';
 import { useNavHistoryStore } from '@/stores/useNavHistoryStore';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { useProfilerSessionStore, type ConnectionStatus } from '@/stores/useProfilerSessionStore';
@@ -24,7 +25,7 @@ import { useProfilerStatsStore } from '@/stores/useProfilerStatsStore';
 import { useRecentFilesStore } from '@/stores/useRecentFilesStore';
 import { resolveInitialViewport } from '@/libs/profiler/initialViewport';
 import { formatBytes } from '@/libs/formatBytes';
-import { buildTickRows, computeSelectionIdxRange } from '@/libs/profiler/canvas/tickOverview';
+import { buildTickRows, computeSelectionIdxRange, recordedTicksOnly } from '@/libs/profiler/canvas/tickOverview';
 import TickOverview from './sections/TickOverview';
 import TimeArea from './sections/TimeArea';
 import OverloadStrip from './sections/OverloadStrip';
@@ -94,6 +95,9 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
 
   const isAttach = kind === 'attach';
   const isTrace = useTraceBackedSession();
+  // P5 — a paused Open session watching its holder's engine is live too, so the subscription follows the live runtime
+  // rather than the session kind. See `isLiveStreamSession` for why that distinction is the whole bug.
+  const hasLiveStream = useLiveStreamSession();
 
   const commitViewRange = useProfilerViewStore((s) => s.commitViewRange);
 
@@ -134,7 +138,7 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
   // any `{0, 0}` sentinel write here would suppress all tick loading. The viewport-restore init
   // below therefore drives off `metadata.tickSummaries` (available in one shot from the API
   // response) rather than `timeAreaTicks` (which only populates after viewRange is non-degenerate).
-  const { ticks: timeAreaTicks, gaugeData, threadInfos, pendingRangesUs } = useProfilerCache(sessionId, isAttach);
+  const { ticks: timeAreaTicks, gaugeData, threadInfos, pendingRangesUs } = useProfilerCache(sessionId, hasLiveStream);
 
   // Single producer for the viewport range-stats. RangeStatsDetail and TopSpansPanel both read the
   // result from `useProfilerStatsStore` so the O(events-in-range) aggregation runs once per click
@@ -176,12 +180,13 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
     });
   }, [viewRangeForStats, isTrace, filePath]);
 
-  // Metadata polling runs in both Trace and Attach modes — server branches on session kind.
-  // Gate on kind so the query doesn't fire for Open (DB) sessions, which would 409.
-  useProfilerMetadata(isTrace || isAttach ? sessionId : null);
-  // Build-progress SSE only meaningful for Trace mode; live-stream SSE only for Attach mode.
+  // Metadata polling runs wherever there is something to serve: an attached capture (trace-backed) or a live runtime.
+  // The gate still matters — an Open session with neither has no profile to serve and the endpoint answers 409.
+  useProfilerMetadata(isTrace || hasLiveStream ? sessionId : null);
+  // Build-progress SSE only meaningful for Trace mode; the live stream follows the live runtime, whichever kind of
+  // session is hosting it.
   useProfilerBuildProgress(isTrace ? sessionId : null);
-  useProfilerLiveStream(isAttach ? sessionId : null);
+  useProfilerLiveStream(hasLiveStream ? sessionId : null);
   // #302 Phase 6: hydrate `useSourceLocationStore` so the Source row in `ProfilerDetail` can
   // resolve span siteIds. Gated on `metadata` being ready: for trace sessions the server only
   // populates the manifest after build completion (same moment metadata is set), so querying
@@ -189,7 +194,7 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
   // For attach sessions metadata arrives after the init handshake which also carries the
   // FileTable + SourceLocationManifest frames, so by the time metadata lands the server's
   // manifest is ready too.
-  useProfilerSourceLocations(isTrace || isAttach ? (metadata ? sessionId : null) : null);
+  useProfilerSourceLocations(isTrace || hasLiveStream ? (metadata ? sessionId : null) : null);
 
   // Tell the store which mode we're in; panels and future renderers can branch off `isLive`.
   // The cleanup wipes every profiler-scoped store so switching sessions (or closing the panel)
@@ -204,7 +209,7 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
   // The cleanup only fires on session *change* (not first mount), so a cold-load URL deep-link
   // on the first session survives.
   useEffect(() => {
-    setIsLive(isAttach);
+    setIsLive(hasLiveStream);
     return () => {
       useProfilerSessionStore.getState().reset();
       useSelectionStore.getState().clearLeaf(); // 3E: clear the profiler selection on the unified bus (silo retired)
@@ -215,7 +220,7 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
       // next one, so each new session starts linked (panels follow the timeline again).
       useProfilerViewStore.getState().setScopeLinked(true);
     };
-  }, [sessionId, isAttach, setIsLive]);
+  }, [sessionId, hasLiveStream, setIsLive]);
 
   const fileName = useMemo(() => {
     if (!filePath) return null;
@@ -228,7 +233,14 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
   // same `computeSelectionIdxRange` the TickOverview uses to draw the selection overlay, so the
   // header label and the overlay always agree. `count` is index-based (tick numbers may have gaps).
   // `tickRows` only rebuilds when tickSummaries change.
-  const tickRows = useMemo(() => buildTickRows(metadata?.tickSummaries), [metadata?.tickSummaries]);
+  // `recordedTicksOnly` for the same reason the strip filters: this label reports the SELECTION, and the selection is
+  // made on the strip. Counting the skeleton ticks the strip does not draw makes the header disagree with what the
+  // user selected — "368 frames" over a window where 200 bars exist, every count in the header inflated by the ticks
+  // that were never recorded.
+  const tickRows = useMemo(
+    () => buildTickRows(recordedTicksOnly(metadata?.tickSummaries)),
+    [metadata?.tickSummaries],
+  );
   const selectedTickRange = useMemo(() => {
     if (tickRows.length === 0) return null;
     if (viewRangeForStats.endUs <= viewRangeForStats.startUs) return null;
@@ -237,7 +249,10 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
     return { first: tickRows[first].tickNumber, last: tickRows[last].tickNumber, count: last - first + 1 };
   }, [tickRows, viewRangeForStats]);
 
-  if (!isTrace && !isAttach) {
+  // "Is there anything to show?", not "which kind of session is this?". A paused Open session that started watching its
+  // holder acquires live data WHILE THIS PANEL IS ALREADY OPEN — asking about `kind` here left it showing the cold
+  // state after Watch live, with the stream connected and ticks arriving behind it.
+  if (!isTrace && !hasLiveStream) {
     return (
       <div className="flex h-full w-full items-center justify-center bg-background">
         <div className="text-center text-sm text-muted-foreground">
@@ -252,17 +267,20 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
     <div className="flex h-full w-full flex-col overflow-hidden bg-background">
       {/* Header */}
       <div className="wb-pane-header flex flex-shrink-0 items-center gap-3 border-b border-border bg-card px-3 py-2 text-fs-base">
-        {isAttach
+        {hasLiveStream
           ? <Radio className="h-4 w-4 text-muted-foreground" aria-label="Live profiler session" />
           : <Activity className="h-4 w-4 text-muted-foreground" aria-label="Trace profiler session" />}
         <span className="font-semibold text-foreground">
-          {isAttach ? (fileName ?? 'Live engine') : (fileName ?? 'Profiler')}
+          {hasLiveStream ? (fileName ?? 'Live engine') : (fileName ?? 'Profiler')}
         </span>
 
-        {isAttach && (
+        {hasLiveStream && (
           <>
             <StatusPill status={connectionStatus} />
-            {connectionStatus !== 'disconnected' && (
+            {/* Disconnect stays keyed on the session KIND, and is the one thing here that genuinely is. It drops an
+                Attach session's own TCP link; a watching database session ends the same thing through "Stop watching"
+                on the paused banner, which also releases the runtime the session is hosting. */}
+            {isAttach && connectionStatus !== 'disconnected' && (
               <Button
                 variant="outline"
                 size="sm"
@@ -280,6 +298,8 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
             <span className="font-mono tabular-nums text-foreground">
               Tick {latestTickNumber.toLocaleString()}
             </span>
+            {/* #805 — on-demand tick capture. Renders itself away unless the session was attached in cherry-pick mode. */}
+            <CaptureControl sessionId={sessionId} />
             {/* Auto-scroll toggle removed in #345 — live mode pins viewRange to the first tick on
                arrival and never moves it automatically thereafter. Pan/zoom interactions are
                always available; the user navigates to new ticks via TickOverview / drag-select. */}
@@ -341,15 +361,15 @@ function ProfilerPanelInner(props: IDockviewPanelProps) {
           <ErrorState message={buildError} />
         ) : isTrace && !metadata ? (
           <BuildProgressOverlay progress={buildProgress} />
-        ) : isAttach && !metadata ? (
+        ) : hasLiveStream && !metadata ? (
           <LiveWaitingOverlay status={connectionStatus} />
         ) : (
           <div className="flex h-full w-full flex-col overflow-hidden">
-            <TickOverview isLive={isAttach} />
+            <TickOverview isLive={hasLiveStream} />
             {/* Overload diagnostics strip — auto-hidden on healthy traces; surfaces multiplier/overrunRatio when the engine throttles. Issue #289. */}
             <OverloadStrip />
             <div className="flex-1 min-h-0">
-              <TimeArea ticks={timeAreaTicks} gaugeData={gaugeData} threadNames={gaugeData.threadNames} threadInfos={threadInfos} pendingRangesUs={pendingRangesUs} isLive={isAttach} />
+              <TimeArea ticks={timeAreaTicks} gaugeData={gaugeData} threadNames={gaugeData.threadNames} threadInfos={threadInfos} pendingRangesUs={pendingRangesUs} isLive={hasLiveStream} />
             </div>
           </div>
         )}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/__tests__/ProfilerPanelLiveGate.test.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/__tests__/ProfilerPanelLiveGate.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { useProfilerSessionStore } from '@/stores/useProfilerSessionStore';
+
+/**
+ * The Profiler panel used to ask `kind === 'attach'` to mean "the data is live".
+ *
+ * That was wrong the moment a paused Open session could start watching its holder's engine (P5): such a session is
+ * `kind === 'open'`, it has a live runtime, a connected stream and ticks arriving — and the panel showed the cold
+ * state, or, past that gate, a header with no Record control. Worse, the capability is acquired **while the panel is
+ * already open**, so the failure appeared only to someone who opened Profiler first and then clicked *Watch live*.
+ *
+ * This is the same defect the Query Analyzer had (`QueryAnalyzerCapabilityGate.test.tsx`) and for the same reason: a
+ * panel gating on the session's KIND rather than on what the session can currently DO. These tests are therefore
+ * written from the live-data question, with the watching database session as a first-class case.
+ */
+const stubs = vi.hoisted(() => ({
+  cache: { ticks: [], gaugeData: { threadNames: [] }, threadInfos: [], pendingRangesUs: [] },
+}));
+
+vi.mock('@/hooks/profiler/useProfilerMetadata', () => ({ useProfilerMetadata: vi.fn() }));
+vi.mock('@/hooks/profiler/useProfilerBuildProgress', () => ({ useProfilerBuildProgress: () => null }));
+vi.mock('@/hooks/profiler/useProfilerLiveStream', () => ({ useProfilerLiveStream: vi.fn() }));
+vi.mock('@/hooks/profiler/useProfilerSourceLocations', () => ({ useProfilerSourceLocations: vi.fn() }));
+vi.mock('@/hooks/profiler/useProfilerStatsWriter', () => ({ useProfilerStatsWriter: vi.fn() }));
+vi.mock('@/hooks/profiler/useProfilerTraceStatus', () => ({ useProfilerTraceStatus: () => false }));
+vi.mock('@/hooks/profiler/useProfilerCache', () => ({ useProfilerCache: () => stubs.cache }));
+vi.mock('@/hooks/usePanelHotkeys', () => ({ usePanelHotkeys: vi.fn() }));
+// Canvas-backed children: jsdom has no 2D context and they are not what these tests are about.
+vi.mock('../sections/TickOverview', () => ({ default: () => <div data-testid="tick-overview" /> }));
+vi.mock('../sections/TimeArea', () => ({ default: () => <div data-testid="time-area" /> }));
+vi.mock('../sections/OverloadStrip', () => ({ default: () => <div data-testid="overload-strip" /> }));
+vi.mock('@/panels/profiler/components/CaptureControl', () => ({
+  default: () => <div data-testid="capture-control" />,
+}));
+vi.mock('@/api/generated/profiles/profiles', () => ({
+  useDeleteApiSessionsSessionIdProfileProfileId: () => ({ mutateAsync: vi.fn() }),
+  usePostApiSessionsSessionIdProfile: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock('@/api/generated/sessions/sessions', () => ({ getApiSessionsId: vi.fn() }));
+
+import ProfilerPanel from '../ProfilerPanel';
+
+const COLD = /Open a trace file or attach to a live engine/i;
+
+// The panel takes dockview panel props; nothing under test reads them.
+const PANEL_PROPS = {} as unknown as React.ComponentProps<typeof ProfilerPanel>;
+
+function renderPanel() {
+  return render(<ProfilerPanel {...PANEL_PROPS} />);
+}
+
+beforeEach(() => {
+  useProfilerSessionStore.setState({ metadata: null, connectionStatus: 'connected' });
+});
+
+afterEach(() => {
+  cleanup();
+  useSessionStore.getState().clearSession();
+  useProfilerSessionStore.getState().reset();
+});
+
+describe('ProfilerPanel — live gating follows the runtime, not the session kind', () => {
+  it('shows the cold state for an Open session with nothing to profile', () => {
+    useSessionStore.setState({ kind: 'open', sessionId: 's1', capabilities: ['database'], isWatchingLive: false });
+    renderPanel();
+    expect(screen.getByText(COLD)).toBeTruthy();
+  });
+
+  /**
+   * The reported bug: Profiler was already open, *Watch live* was clicked, and the panel kept showing the cold state
+   * with no way to record — the capability arrived after mount.
+   */
+  it('leaves the cold state when an already-open panel starts watching', () => {
+    useSessionStore.setState({ kind: 'open', sessionId: 's1', capabilities: ['database'], isWatchingLive: false });
+    const { rerender } = renderPanel();
+    expect(screen.getByText(COLD)).toBeTruthy();
+
+    // Watch live → the server reports the profiler capability and the session re-reads.
+    useSessionStore.setState({ capabilities: ['database', 'profiler'], isWatchingLive: true });
+    rerender(<ProfilerPanel {...PANEL_PROPS} />);
+
+    expect(screen.queryByText(COLD)).toBeNull();
+  });
+
+  it('renders the Record control for a watching database session', () => {
+    useSessionStore.setState({
+      kind: 'open', sessionId: 's1', capabilities: ['database', 'profiler'], isWatchingLive: true,
+    });
+    useProfilerSessionStore.setState({ metadata: { tickSummaries: [] } as never });
+    renderPanel();
+
+    expect(screen.queryByText(COLD)).toBeNull();
+    expect(screen.getByTestId('capture-control')).toBeTruthy();
+  });
+
+  it('still renders the Record control for an Attach session', () => {
+    useSessionStore.setState({ kind: 'attach', sessionId: 's1', capabilities: ['profiler'], isWatchingLive: false });
+    useProfilerSessionStore.setState({ metadata: { tickSummaries: [] } as never });
+    renderPanel();
+
+    expect(screen.queryByText(COLD)).toBeNull();
+    expect(screen.getByTestId('capture-control')).toBeTruthy();
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/components/CaptureControl.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/components/CaptureControl.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { Circle, Square, TriangleAlert } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { applyWorkbenchAuthHeaders } from '@/api/bootstrapToken';
+import { logError, logInfo } from '@/stores/useLogStore';
+import { useProfilerSessionStore, type CaptureState } from '@/stores/useProfilerSessionStore';
+
+interface Props {
+  sessionId: string | null;
+}
+
+const DEFAULT_TICKS = 100;
+
+/**
+ * On-demand tick capture control (#805) — Record / Stop plus the tick budget, for live attach sessions.
+ *
+ * The unit is ticks rather than milliseconds on purpose: the timeline draws one bar per tick, so "100 ticks" is
+ * exactly 100 bars you can select, whereas a duration buys an unpredictable number of them — Typhon throttles its
+ * tick rate under overload, which is precisely when someone is recording.
+ *
+ * Only rendered for cherry-pick sessions: in capture-everything mode there is no window to arm, and offering a
+ * disabled Record button would imply the mode can be changed after attaching, which it cannot.
+ */
+export default function CaptureControl({ sessionId }: Props) {
+  const captureState = useProfilerSessionStore((s) => s.captureState);
+  const [tickCount, setTickCount] = useState<string>(String(DEFAULT_TICKS));
+  const [busy, setBusy] = useState(false);
+
+  if (!sessionId || !captureState || captureState.mode !== 'CherryPick') {
+    return null;
+  }
+
+  const parsed = Number(tickCount);
+  const countValid = Number.isInteger(parsed) && parsed > 0 && parsed <= 1_000_000;
+  const recording = captureState.state === 'Recording';
+
+  const send = async (ticks: number) => {
+    setBusy(true);
+    try {
+      const headers = applyWorkbenchAuthHeaders(new Headers({ 'Content-Type': 'application/json' }), sessionId);
+      const resp = await fetch(`/api/sessions/${sessionId}/profiler/capture`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ tickCount: ticks }),
+      });
+      if (!resp.ok) {
+        throw new Error(`capture request failed: ${resp.status}`);
+      }
+      logInfo(ticks > 0 ? `Recording next ${ticks} tick(s)` : 'Capture stopped', { sessionId, ticks });
+    } catch (err) {
+      logError('Capture control failed', { sessionId, ticks, error: String(err) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2" data-testid="capture-control">
+      {recording ? (
+        <Button
+          size="sm"
+          variant="destructive"
+          disabled={busy}
+          onClick={() => void send(0)}
+          data-testid="capture-stop"
+        >
+          <Square className="mr-1 size-3" />
+          Stop
+        </Button>
+      ) : (
+        <>
+          <Input
+            value={tickCount}
+            onChange={(e) => setTickCount(e.target.value)}
+            className="h-7 w-20 text-fs-sm"
+            aria-label="Ticks to record"
+            data-testid="capture-tick-count"
+          />
+          <Button
+            size="sm"
+            disabled={busy || !countValid}
+            onClick={() => void send(parsed)}
+            data-testid="capture-record"
+          >
+            <Circle className="mr-1 size-3 fill-current" />
+            Record
+          </Button>
+        </>
+      )}
+
+      <CaptureBadge state={captureState} />
+    </div>
+  );
+}
+
+/** Progress / status pill: "recording 37/100", "idle", or a numbering warning. */
+function CaptureBadge({ state }: { state: CaptureState }) {
+  if (state.tickNumberingSuspect) {
+    return (
+      <span
+        className="flex items-center gap-1 rounded bg-destructive/10 px-2 py-0.5 text-fs-xs text-destructive"
+        title="A TickStart record was lost, so reported tick numbers no longer match the engine's. Re-attach to recover."
+        data-testid="capture-numbering-warning"
+      >
+        <TriangleAlert className="size-3" />
+        tick numbers unreliable
+      </span>
+    );
+  }
+
+  if (state.state === 'Recording') {
+    const captured = Math.max(state.recordedTicks, 0);
+    return (
+      <span className="rounded bg-primary/10 px-2 py-0.5 text-fs-xs text-primary" data-testid="capture-progress">
+        recording — {state.remaining} tick{state.remaining === 1 ? '' : 's'} left ({captured} captured)
+      </span>
+    );
+  }
+
+  return (
+    <span className="rounded bg-muted px-2 py-0.5 text-fs-xs text-muted-foreground" data-testid="capture-idle">
+      {state.recordedTicks > 0 ? `idle — ${state.recordedTicks} tick(s) captured` : 'idle — not recording'}
+      {!state.tickNumbersAbsolute && ' · ticks relative to attach'}
+    </span>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/components/__tests__/CaptureControl.test.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/components/__tests__/CaptureControl.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import CaptureControl from '@/panels/profiler/components/CaptureControl';
+import { useProfilerSessionStore, type CaptureState } from '@/stores/useProfilerSessionStore';
+
+// On-demand tick capture (#805) — the Record / Stop control. These cover the three things a user can actually get
+// wrong or be misled by: a control that appears when it cannot work, a budget that is silently mangled, and a
+// timeline whose tick numbers are quietly untrustworthy.
+
+const SESSION = '11111111-2222-3333-4444-555555555555';
+
+function state(overrides: Partial<CaptureState> = {}): CaptureState {
+  return {
+    state: 'Idle',
+    remaining: 0,
+    recordedTicks: 0,
+    mode: 'CherryPick',
+    tickNumbersAbsolute: true,
+    tickNumberingSuspect: false,
+    bytesReceived: 1_000,
+    bytesRetained: 100,
+    ...overrides,
+  };
+}
+
+function setCapture(s: CaptureState | null) {
+  useProfilerSessionStore.setState({ captureState: s });
+}
+
+describe('CaptureControl', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    setCapture(null);
+  });
+
+  it('renders nothing in capture-everything mode', () => {
+    // There is no window to arm, and a disabled Record button would imply the mode can be changed after attaching.
+    setCapture(state({ mode: 'Everything', state: 'Everything' }));
+    const { container } = render(<CaptureControl sessionId={SESSION} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing before the first capture-state frame arrives', () => {
+    setCapture(null);
+    const { container } = render(<CaptureControl sessionId={SESSION} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('arms the requested tick budget', async () => {
+    setCapture(state());
+    render(<CaptureControl sessionId={SESSION} />);
+
+    fireEvent.change(screen.getByTestId('capture-tick-count'), { target: { value: '250' } });
+    fireEvent.click(screen.getByTestId('capture-record'));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`/api/sessions/${SESSION}/profiler/capture`);
+    expect(JSON.parse(init.body)).toEqual({ tickCount: 250 });
+  });
+
+  it('refuses a non-positive or non-integer budget instead of sending it', () => {
+    setCapture(state());
+    render(<CaptureControl sessionId={SESSION} />);
+
+    for (const bad of ['0', '-5', '2.5', 'abc', '']) {
+      fireEvent.change(screen.getByTestId('capture-tick-count'), { target: { value: bad } });
+      expect((screen.getByTestId('capture-record') as HTMLButtonElement).disabled).toBe(true);
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows Stop while recording, and stopping sends a zero budget', async () => {
+    setCapture(state({ state: 'Recording', remaining: 37, recordedTicks: 63 }));
+    render(<CaptureControl sessionId={SESSION} />);
+
+    expect(screen.queryByTestId('capture-record')).toBeNull();
+    expect(screen.getByTestId('capture-progress').textContent).toContain('37 ticks left');
+
+    fireEvent.click(screen.getByTestId('capture-stop'));
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ tickCount: 0 });
+  });
+
+  it('warns when tick numbering can no longer be trusted', () => {
+    // A dropped TickStart renumbers everything after it with nothing in the data looking unusual, so the UI has to
+    // say so — a plausible-looking wrong timeline is worse than an admitted one.
+    setCapture(state({ tickNumberingSuspect: true, state: 'Recording', remaining: 5 }));
+    render(<CaptureControl sessionId={SESSION} />);
+    expect(screen.getByTestId('capture-numbering-warning')).toBeTruthy();
+  });
+
+  it('says so when ticks are numbered relative to attach', () => {
+    // No gauges ⇒ no absolute tick number exists anywhere on the live wire.
+    setCapture(state({ tickNumbersAbsolute: false }));
+    render(<CaptureControl sessionId={SESSION} />);
+    expect(screen.getByTestId('capture-idle').textContent).toContain('relative to attach');
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/TickOverview.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/TickOverview.tsx
@@ -3,15 +3,18 @@ import {
   BAR_AREA_BOTTOM_RESERVED,
   BAR_AREA_TOP,
   BAR_LEFT_PAD,
-  BAR_WIDTH,
   DRAG_THRESHOLD_PX,
   TIMELINE_HEIGHT,
   buildTickRows,
   computeSelectionIdxRange,
   drawTickOverview,
   hitTestScrollbar,
+  barsThatFit,
+  computeBarOffsets,
   hitTestTick,
   isInHelpHitZone,
+  missingTicksBefore,
+  recordedTicksOnly,
   type TickRow,
 } from '@/libs/profiler/canvas/tickOverview';
 import { formatDuration } from '@/libs/profiler/canvas/canvasUtils';
@@ -47,6 +50,11 @@ const OVERVIEW_HELP_LINES: string[] = [
   '  Orange overlay = ticks overlapping the current viewport.',
   '  ◀ / ▶ chevrons mean the selection extends past the visible',
   '    window.',
+  '  Grey hatched band = the tick axis JUMPS here. Only recorded',
+  '    ticks are drawn, so a cherry-picked capture puts e.g.',
+  '    tick 4 next to tick 8. Bars either side of the line are',
+  '    NOT adjacent in time — hover the right-hand one to see',
+  '    how many ticks were skipped.',
   '',
   'Bar colour:',
   '  Throttle multiplier (when > 1) wins over the P95 colouring,',
@@ -160,7 +168,15 @@ export default function TickOverview({ isLive = false }: Props) {
   // #289 — both trace and live modes derive from `metadata.tickSummaries`. In live mode the array grows over time
   // via SSE deltas (server-side IncrementalCacheBuilder finalizes ticks → store appends). The `buildTickRows`
   // helper handles the float-drift boundary clamp; see its doc for why.
-  const tickRows: TickRow[] = useMemo(() => buildTickRows(metadata?.tickSummaries), [metadata?.tickSummaries]);
+  //
+  // #805 — `recordedTicksOnly` first. A cherry-pick capture keeps a skeleton for every tick it did NOT record, purely
+  // to hold the tick numbering; drawing those would bury the armed windows in thousands of unclickable bars. Filtering
+  // at the ROW level rather than at the draw call is what keeps hit-testing, wheel navigation, the scrollbar and the
+  // selection range consistent — every one of them indexes into `tickRows` positionally.
+  const tickRows: TickRow[] = useMemo(
+    () => buildTickRows(recordedTicksOnly(metadata?.tickSummaries)),
+    [metadata?.tickSummaries],
+  );
 
   // GC marker source: every GC suspension wraps a stop-the-world window, so any tick that overlaps one
   // is a tick where GC happened. Merge-walk both sorted arrays in parallel — O(ticks + suspensions),
@@ -229,8 +245,10 @@ export default function TickOverview({ isLive = false }: Props) {
       return;
     }
     const w = canvasWidthRef.current;
-    const maxVisible = w > 0 ? Math.max(1, Math.floor((w - BAR_LEFT_PAD) / BAR_WIDTH)) : tickRows.length;
     const sr = scrollRangeRef.current;
+    // barsThatFit, not width/BAR_WIDTH: discontinuity bands consume horizontal space, so a pitch-based count
+    // overflows the canvas by the total band width and clips the right-hand bars.
+    const maxVisible = w > 0 ? Math.max(1, barsThatFit(tickRows, sr.startIdx, w - BAR_LEFT_PAD)) : tickRows.length;
     const visibleCount = sr.endIdx - sr.startIdx;
     const desiredVisible = Math.min(maxVisible, tickRows.length);
     if (visibleCount <= 0) {
@@ -259,10 +277,10 @@ export default function TickOverview({ isLive = false }: Props) {
     canvasWidthRef.current = rect.width;
 
     // Width-aware self-correction — init effect runs before first layout, so scrollWindow may be larger than the
-    // canvas can show. Clamp down to what fits at BAR_WIDTH.
+    // canvas can show. Clamp down to what actually fits, bands included.
     if (!isLive && tickRows.length > 0 && rect.width > 0) {
-      const maxVisible = Math.max(1, Math.min(tickRows.length, Math.floor((rect.width - BAR_LEFT_PAD) / BAR_WIDTH)));
       const sr0 = scrollRangeRef.current;
+      const maxVisible = Math.max(1, Math.min(tickRows.length, barsThatFit(tickRows, sr0.startIdx, rect.width - BAR_LEFT_PAD)));
       const currentVisible = sr0.endIdx - sr0.startIdx;
       if (currentVisible !== maxVisible || sr0.endIdx > tickRows.length) {
         const newStart = Math.max(0, Math.min(tickRows.length - maxVisible, sr0.startIdx));
@@ -343,8 +361,13 @@ export default function TickOverview({ isLive = false }: Props) {
     const canvas = canvasRef.current;
     if (!canvas) return -1;
     const rect = canvas.getBoundingClientRect();
-    return hitTestTick(clientX - rect.left, rect.width, scrollRangeRef.current);
-  }, []);
+    const sr = scrollRangeRef.current;
+    // The same offset table the draw pass builds. Bars are no longer on a uniform pitch — a discontinuity band takes
+    // real space — so hit-testing has to read the layout rather than divide by BAR_WIDTH, or every click past the
+    // first gap selects a neighbouring tick. Recomputed here rather than cached because pointer events and the rAF
+    // draw run at different times, and a stale table misaims clicks precisely while the user is scrolling.
+    return hitTestTick(clientX - rect.left, rect.width, sr, computeBarOffsets(tickRows, sr.startIdx, sr.endIdx));
+  }, [tickRows]);
 
   const panBy = useCallback((deltaTicks: number) => {
     const sr = scrollRangeRef.current;
@@ -627,6 +650,19 @@ export default function TickOverview({ isLive = false }: Props) {
         `Duration: ${formatDuration(tick.durationUs)} (${formatDuration(allocatedUs)} allocated)`,
         `Events: ${tick.eventCount.toLocaleString()}`,
       ];
+      // The dashed marker says a break is there; this says how big it is, which is the part that changes how you read
+      // the neighbouring bars. Named as "not recorded" rather than "missing": with cherry-picked capture the ticks did
+      // run, they were simply never armed, and "missing" would suggest data loss.
+      const skipped = missingTicksBefore(tickRows, idx);
+      if (skipped > 0) {
+        const from = tickRows[idx - 1].tickNumber + 1;
+        const to = tick.tickNumber - 1;
+        lines.push(
+          skipped === 1
+            ? `Gap before: tick ${from} not recorded`
+            : `Gap before: ticks ${from}–${to} not recorded (${skipped.toLocaleString()})`,
+        );
+      }
       // v9 (#289 follow-up): expose throttle + metronome diagnostics when present.
       const mult = tick.tickMultiplier ?? 0;
       if (mult > 1) {

--- a/tools/Typhon.Workbench/ClientApp/src/shell/banners/PausedBanner.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/banners/PausedBanner.tsx
@@ -1,6 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { PauseCircle } from 'lucide-react';
 import { getApiSessionsId, useGetApiSessionsIdState } from '@/api/generated/sessions/sessions';
+import { Button } from '@/components/ui/button';
+import { applyWorkbenchAuthHeaders } from '@/api/bootstrapToken';
+import { logError, logInfo } from '@/stores/useLogStore';
 import { useSessionStore } from '@/stores/useSessionStore';
 
 /**
@@ -35,6 +38,11 @@ export default function PausedBanner() {
   const sessionId = useSessionStore((s) => s.sessionId);
   const kind = useSessionStore((s) => s.kind);
   const setSession = useSessionStore((s) => s.setSession);
+  const profilerEndpoint = useSessionStore((s) => s.profilerEndpoint);
+  const isWatchingLive = useSessionStore((s) => s.isWatchingLive);
+
+  const [busy, setBusy] = useState(false);
+  const [watchError, setWatchError] = useState<string | null>(null);
 
   // Poll whenever there is a database session, paused or not: a LIVE session is exactly the one that can be asked to
   // yield, and gating this on `isPaused` meant the Workbench released the database while the UI carried on as though
@@ -56,6 +64,45 @@ export default function PausedBanner() {
     void getApiSessionsId(sessionId).then((r) => setSession(r.data));
   }, [serverPaused, isPaused, sessionId, setSession]);
 
+  /**
+   * Start or stop watching the holder's live engine.
+   *
+   * The session is re-read on success rather than patched locally: watching flips the session's CAPABILITIES
+   * server-side (P3 reports `profiler` once a live runtime exists), and every profiler panel gates on those. Guessing
+   * the new capability set on the client is the #617 seam that made an attached capture render nothing.
+   */
+  const toggleWatch = async (watch: boolean) => {
+    if (!sessionId || busy) {
+      return;
+    }
+    setBusy(true);
+    setWatchError(null);
+    try {
+      const headers = applyWorkbenchAuthHeaders(new Headers({ 'Content-Type': 'application/json' }), sessionId);
+      const resp = await fetch(`/api/sessions/${sessionId}/profiler/watch`, {
+        method: watch ? 'POST' : 'DELETE',
+        headers,
+        // Cherry-pick: watching a live app is the case the on-demand capture exists for. Recording every tick of a
+        // session you opened to observe someone else's run is exactly the volume problem #805 set out to remove.
+        body: watch ? JSON.stringify({ cherryPick: true }) : undefined,
+      });
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}`);
+      }
+      const refreshed = await getApiSessionsId(sessionId);
+      setSession(refreshed.data);
+      logInfo(watch ? 'Watching the live engine' : 'Stopped watching the live engine', { sessionId, profilerEndpoint });
+    } catch (err) {
+      const detail = (err as Error)?.message ?? String(err);
+      setWatchError(watch ? `Could not watch ${profilerEndpoint}: ${detail}` : `Could not stop watching: ${detail}`);
+      logError('Watch live failed', { sessionId, profilerEndpoint, error: detail });
+    } finally {
+      // Always — clearing this only on the error path would leave the button reading "Connecting…" for ever on the
+      // success path, since nothing here unmounts the banner (the database is still paused).
+      setBusy(false);
+    }
+  };
+
   if (!isPaused) {
     return null;
   }
@@ -74,7 +121,37 @@ export default function PausedBanner() {
           {reason ??
             'Another process is using this database. The Workbench reopens it automatically when that process exits.'}
         </p>
+        {isWatchingLive && (
+          <p className="mt-0.5 text-fs-sm opacity-90" data-testid="paused-banner-watching">
+            Watching {profilerEndpoint} — arm a recording from the Profiler panel.
+          </p>
+        )}
+        {watchError && (
+          <p className="mt-0.5 text-fs-sm text-destructive" data-testid="paused-banner-watch-error">
+            {watchError}
+          </p>
+        )}
       </div>
+      {/* The holder advertises a profiler port only when it is a Typhon app with live telemetry enabled, which is
+          exactly when watching it is possible — and this banner is the moment the user learns their app took the
+          database, so it is where the offer belongs. */}
+      {profilerEndpoint && (
+        <Button
+          size="sm"
+          variant={isWatchingLive ? 'secondary' : 'default'}
+          className="h-6 shrink-0 text-fs-sm"
+          onClick={() => void toggleWatch(!isWatchingLive)}
+          disabled={busy}
+          data-testid="paused-banner-watch"
+          title={
+            isWatchingLive
+              ? 'Stop watching the running engine — the database stays paused'
+              : `Watch the running engine live at ${profilerEndpoint}`
+          }
+        >
+          {busy ? 'Working…' : isWatchingLive ? 'Stop watching' : 'Watch live'}
+        </Button>
+      )}
     </div>
   );
 }

--- a/tools/Typhon.Workbench/ClientApp/src/shell/banners/ReconnectBanner.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/banners/ReconnectBanner.tsx
@@ -76,9 +76,17 @@ export default function ReconnectBanner() {
     setActionError(null);
     try {
       await captureAndAnalyse(sessionId);
-      // Session transitions to 'trace'; banner self-hides via the visibility gate above.
+      // The banner used to disappear on its own because the session became a 'trace' session and the visibility gate
+      // above stopped matching. #613 deleted that session kind and #621 made the replay attach back to THIS session, so
+      // the kind stays 'attach' and the gate keeps matching — nothing unmounts us. Dismiss explicitly: the disconnect
+      // has been dealt with, and re-offering "capture what we have" for a buffer already saved invites a duplicate.
+      setDismissed(dismissKey);
     } catch (e) {
       setActionError((e as Error)?.message ?? 'Capture & Analyse failed.');
+    } finally {
+      // MUST be finally, not the catch arm. Clearing it only on failure was safe only while success unmounted us; it
+      // now leaves the button reading 'Capturing…' for ever on the SUCCESS path — the capture is on disk and the UI
+      // says it is still running.
       setIsCapturing(false);
     }
   }

--- a/tools/Typhon.Workbench/ClientApp/src/shell/banners/__tests__/PausedBanner.test.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/banners/__tests__/PausedBanner.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useSessionStore } from '@/stores/useSessionStore';
+
+/**
+ * P5 — *Watch live* on the paused banner.
+ *
+ * A paused session is the moment the user learns their application took the database. When that application is a
+ * Typhon app with a live port, watching it is possible right there — and reaching it as an Open session (rather than
+ * through Connect → Attach) is what keeps Profiles, the correlation bridges and every database view available.
+ *
+ * The offer is keyed on `profilerEndpoint`: the holder advertises it in `db.lock`, so non-null means "there is a live
+ * engine to watch". An editor or a backup holding the database reports null, and offering to watch that would only
+ * produce a connection refused.
+ */
+const spies = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  useState: vi.fn(),
+}));
+
+vi.mock('@/api/generated/sessions/sessions', () => ({
+  getApiSessionsId: spies.getSession,
+  useGetApiSessionsIdState: spies.useState,
+}));
+vi.mock('@/api/bootstrapToken', () => ({
+  applyWorkbenchAuthHeaders: (h: Headers) => h,
+}));
+
+import PausedBanner from '../PausedBanner';
+
+const PAUSED_DTO = {
+  sessionId: 'sess-A',
+  kind: 'Open',
+  state: 'Ready',
+  filePath: 'C:/db/world.typhon',
+  isPaused: true,
+  reason: 'Database released to pid 1234.',
+};
+
+function setPaused(over: { profilerEndpoint?: string | null; isWatchingLive?: boolean } = {}) {
+  useSessionStore.setState({
+    kind: 'open',
+    sessionId: 'sess-A',
+    isPaused: true,
+    pausedReason: 'Database released to pid 1234.',
+    profilerEndpoint: over.profilerEndpoint ?? null,
+    isWatchingLive: over.isWatchingLive ?? false,
+  });
+}
+
+function stubFetch(ok: boolean): ReturnType<typeof vi.fn> {
+  const f = vi.fn().mockResolvedValue({ ok, status: ok ? 200 : 500 } as Response);
+  globalThis.fetch = f as unknown as typeof fetch;
+  return f;
+}
+
+beforeEach(() => {
+  // The banner polls /state; keep it agreeing with the store so the poll never triggers a re-read of its own.
+  spies.useState.mockReturnValue({ data: { data: { isPaused: true } } });
+  spies.getSession.mockResolvedValue({ data: { ...PAUSED_DTO, isWatchingLive: true, profilerEndpoint: 'localhost:9100' } });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  useSessionStore.getState().clearSession();
+});
+
+describe('PausedBanner — Watch live', () => {
+  it('offers nothing to watch when the holder advertises no endpoint', () => {
+    setPaused({ profilerEndpoint: null });
+    render(<PausedBanner />);
+
+    expect(screen.getByTestId('paused-banner')).toBeTruthy();
+    expect(screen.queryByTestId('paused-banner-watch')).toBeNull();
+  });
+
+  it('offers Watch live when the holder advertises an endpoint', () => {
+    setPaused({ profilerEndpoint: 'localhost:9100' });
+    render(<PausedBanner />);
+
+    const btn = screen.getByTestId('paused-banner-watch');
+    expect(btn.textContent).toMatch(/Watch live/i);
+  });
+
+  it('renders nothing at all when the session is not paused, endpoint or not', () => {
+    setPaused({ profilerEndpoint: 'localhost:9100' });
+    useSessionStore.setState({ isPaused: false });
+    const { container } = render(<PausedBanner />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('POSTs the watch request in cherry-pick mode and re-reads the session', async () => {
+    const f = stubFetch(true);
+    setPaused({ profilerEndpoint: 'localhost:9100' });
+    render(<PausedBanner />);
+
+    fireEvent.click(screen.getByTestId('paused-banner-watch'));
+
+    await waitFor(() => expect(f).toHaveBeenCalled());
+    const [url, init] = f.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/sessions/sess-A/profiler/watch');
+    expect(init.method).toBe('POST');
+    // Recording every tick of a session opened to observe someone else's run is the volume problem #805 removes.
+    expect(JSON.parse(init.body as string)).toEqual({ cherryPick: true });
+
+    // The session must be re-read: watching flips server-side CAPABILITIES, and every profiler panel gates on those.
+    await waitFor(() => expect(spies.getSession).toHaveBeenCalledWith('sess-A'));
+    await waitFor(() => expect(useSessionStore.getState().isWatchingLive).toBe(true));
+  });
+
+  it('offers Stop watching while watching, and DELETEs on click', async () => {
+    const f = stubFetch(true);
+    setPaused({ profilerEndpoint: 'localhost:9100', isWatchingLive: true });
+    render(<PausedBanner />);
+
+    expect(screen.getByTestId('paused-banner-watching').textContent).toMatch(/localhost:9100/);
+    const btn = screen.getByTestId('paused-banner-watch');
+    expect(btn.textContent).toMatch(/Stop watching/i);
+
+    fireEvent.click(btn);
+    await waitFor(() => expect(f).toHaveBeenCalled());
+    const [url, init] = f.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/sessions/sess-A/profiler/watch');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  /**
+   * The button must come back. Clearing the busy flag only on success would strand it on "Working…" for ever — nothing
+   * unmounts this banner on failure, because the database is still paused.
+   */
+  it('surfaces a failure and restores the button', async () => {
+    stubFetch(false);
+    setPaused({ profilerEndpoint: 'localhost:9100' });
+    render(<PausedBanner />);
+
+    fireEvent.click(screen.getByTestId('paused-banner-watch'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('paused-banner-watch-error').textContent).toMatch(/localhost:9100/);
+    });
+    const btn = screen.getByTestId('paused-banner-watch') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent).toMatch(/Watch live/i);
+    expect(spies.getSession).not.toHaveBeenCalled();
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/shell/banners/__tests__/ReconnectBanner.test.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/banners/__tests__/ReconnectBanner.test.tsx
@@ -118,3 +118,38 @@ describe('UC-OBS-07 — reconnect banner action wiring (AC4.8, GAP-22)', () => {
     expect(screen.queryByTestId('engine-reconnect-banner')).toBeTruthy();
   });
 });
+
+/**
+ * The button used to be left reading `Capturing…` for ever on the SUCCESS path. It cleared the flag only in its catch
+ * arm, which was correct only while a successful capture turned the session into a 'trace' session and the visibility
+ * gate unmounted the banner. #613 deleted that session kind and #621 attaches the replay back to the SAME session, so
+ * the banner survives its own success — and the user watches a spinner for a capture that is already on disk.
+ */
+describe('Capture & Analyse — the banner must not get stuck on Capturing…', () => {
+  it('leaves the capturing state after a successful capture', async () => {
+    setAttachDisconnected(null);
+    const { container } = render(<ReconnectBanner />);
+
+    fireEvent.click(screen.getByTestId('engine-reconnect-banner-capture'));
+    await waitFor(() => expect(spies.captureAndAnalyse).toHaveBeenCalledWith('sess-A'));
+
+    // The disconnect has been dealt with, so the banner retires itself rather than re-offering a duplicate capture.
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+
+  it('restores the button after a failed capture so it can be retried', async () => {
+    spies.captureAndAnalyse.mockRejectedValueOnce(new Error('disk full'));
+    setAttachDisconnected(null);
+    render(<ReconnectBanner />);
+
+    fireEvent.click(screen.getByTestId('engine-reconnect-banner-capture'));
+
+    await waitFor(() => {
+      const button = screen.getByTestId('engine-reconnect-banner-capture') as HTMLButtonElement;
+      expect(button.disabled).toBe(false);
+      expect(button.textContent).toMatch(/Capture what we have/i);
+    });
+    // The banner stays up on failure — there is still something to capture.
+    expect(screen.queryByTestId('engine-reconnect-banner')).toBeTruthy();
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/shell/dialogs/ConnectDialog.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/dialogs/ConnectDialog.tsx
@@ -58,10 +58,10 @@ export default function ConnectDialog({ open, initialTab, onOpenChange }: Props)
  }
  };
 
- const handleOpenAttach = async (endpoint: string) => {
- logInfo(`Attaching to engine: ${endpoint}`, { endpoint });
+ const handleOpenAttach = async (endpoint: string, cherryPick: boolean) => {
+ logInfo(`Attaching to engine: ${endpoint}`, { endpoint, cherryPick });
  try {
- const response = await postAttach.mutateAsync({ data: { endpointAddress: endpoint } });
+ const response = await postAttach.mutateAsync({ data: { endpointAddress: endpoint, cherryPick } });
  const dto = response.data;
  setSession(dto);
  logInfo(`Attach session opened`, { sessionId: dto.sessionId, endpoint });

--- a/tools/Typhon.Workbench/ClientApp/src/shell/dialogs/tabs/AttachTab.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/dialogs/tabs/AttachTab.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 interface Props {
-  onAttach: (endpoint: string) => void;
+  onAttach: (endpoint: string, cherryPick: boolean) => void;
   isAttaching?: boolean;
 }
 
@@ -17,6 +17,10 @@ const ENDPOINT_REGEX = /^[^\s:]+(?::\d{1,5})?$/;
  */
 export default function AttachTab({ onAttach, isAttaching }: Props) {
   const [endpoint, setEndpoint] = useState<string>('localhost:9100');
+  // #805 — chosen per attach, deliberately not remembered: "show me everything this run does" and "let me grab the 100
+  // ticks around that spike" are both legitimate on the same engine minutes apart, so a sticky default would be wrong
+  // half the time. Defaults to capture-everything, which is the behaviour every attach had before #805.
+  const [cherryPick, setCherryPick] = useState<boolean>(false);
 
   const trimmed = endpoint.trim();
   const shapeValid = ENDPOINT_REGEX.test(trimmed);
@@ -54,11 +58,50 @@ export default function AttachTab({ onAttach, isAttaching }: Props) {
         </p>
       )}
 
+      <fieldset className="flex shrink-0 flex-col gap-2 rounded border border-border p-3">
+        <legend className="px-1 text-fs-sm text-muted-foreground">What to capture</legend>
+
+        <label className="flex cursor-pointer items-start gap-2">
+          <input
+            type="radio"
+            name="capture-mode"
+            className="mt-1"
+            checked={!cherryPick}
+            onChange={() => setCherryPick(false)}
+            data-testid="attach-mode-everything"
+          />
+          <span className="flex flex-col">
+            <span className="text-fs-base">Capture everything</span>
+            <span className="text-fs-xs text-muted-foreground">
+              Records every tick for as long as the session is attached.
+            </span>
+          </span>
+        </label>
+
+        <label className="flex cursor-pointer items-start gap-2">
+          <input
+            type="radio"
+            name="capture-mode"
+            className="mt-1"
+            checked={cherryPick}
+            onChange={() => setCherryPick(true)}
+            data-testid="attach-mode-cherry-pick"
+          />
+          <span className="flex flex-col">
+            <span className="text-fs-base">Cherry-pick ticks</span>
+            <span className="text-fs-xs text-muted-foreground">
+              Keeps the tick timeline and gauges, but records full detail only for the ticks you ask for with
+              <span className="font-medium"> Record</span>. Much smaller sessions.
+            </span>
+          </span>
+        </label>
+      </fieldset>
+
       <div className="flex-1" />
 
       <div className="flex shrink-0 justify-end gap-2">
         <Button
-          onClick={() => canAttach && onAttach(trimmed)}
+          onClick={() => canAttach && onAttach(trimmed, cherryPick)}
           disabled={!canAttach}
           className="text-fs-lg"
         >

--- a/tools/Typhon.Workbench/ClientApp/src/shell/dialogs/tabs/__tests__/AttachTab.test.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/dialogs/tabs/__tests__/AttachTab.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import AttachTab from '@/shell/dialogs/tabs/AttachTab';
+
+// On-demand tick capture (#805) — the attach-time mode choice. The default is load-bearing: it is what every
+// existing attach workflow gets, so it must remain capture-everything.
+
+describe('AttachTab capture mode', () => {
+  afterEach(cleanup);
+
+  it('defaults to capture-everything so existing workflows are unchanged', () => {
+    const onAttach = vi.fn();
+    render(<AttachTab onAttach={onAttach} />);
+
+    expect((screen.getByTestId('attach-mode-everything') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('attach-mode-cherry-pick') as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Attach' }));
+    expect(onAttach).toHaveBeenCalledWith('localhost:9100', false);
+  });
+
+  it('passes cherryPick when the user picks it', () => {
+    const onAttach = vi.fn();
+    render(<AttachTab onAttach={onAttach} />);
+
+    fireEvent.click(screen.getByTestId('attach-mode-cherry-pick'));
+    fireEvent.click(screen.getByRole('button', { name: 'Attach' }));
+
+    expect(onAttach).toHaveBeenCalledWith('localhost:9100', true);
+  });
+
+  it('keeps the mode choice independent of endpoint validation', () => {
+    const onAttach = vi.fn();
+    render(<AttachTab onAttach={onAttach} />);
+
+    fireEvent.click(screen.getByTestId('attach-mode-cherry-pick'));
+    fireEvent.change(screen.getByPlaceholderText('localhost:9100'), { target: { value: 'bad endpoint' } });
+
+    expect((screen.getByRole('button', { name: 'Attach' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId('attach-mode-cherry-pick') as HTMLInputElement).checked).toBe(true);
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useProfilerSessionStore.capture.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useProfilerSessionStore.capture.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { useProfilerSessionStore, type CaptureState } from '@/stores/useProfilerSessionStore';
+
+// On-demand tick capture (#805) — the store's handling of `captureStateChanged`.
+
+function state(overrides: Partial<CaptureState> = {}): CaptureState {
+  return {
+    state: 'Idle',
+    remaining: 0,
+    recordedTicks: 0,
+    mode: 'CherryPick',
+    tickNumbersAbsolute: true,
+    tickNumberingSuspect: false,
+    bytesReceived: 0,
+    bytesRetained: 0,
+    ...overrides,
+  };
+}
+
+describe('useProfilerSessionStore — capture state', () => {
+  afterEach(() => {
+    useProfilerSessionStore.setState({ captureState: null });
+  });
+
+  it('starts null so the control can stay hidden until the server has spoken', () => {
+    expect(useProfilerSessionStore.getState().captureState).toBeNull();
+  });
+
+  it('applies a captureStateChanged frame', () => {
+    useProfilerSessionStore.getState().applyLiveBatch([
+      { kind: 'captureStateChanged', captureState: state({ state: 'Recording', remaining: 12 }) },
+    ]);
+    expect(useProfilerSessionStore.getState().captureState?.state).toBe('Recording');
+    expect(useProfilerSessionStore.getState().captureState?.remaining).toBe(12);
+  });
+
+  it('takes the LAST frame in a batch, not the first', () => {
+    // The state is a snapshot rather than a delta, and the stream is coalesced into rAF batches — so an intermediate
+    // frame in the same batch is already stale by the time it is applied. Applying it last-wins is what stops the
+    // badge counting backwards on a busy engine.
+    useProfilerSessionStore.getState().applyLiveBatch([
+      { kind: 'captureStateChanged', captureState: state({ state: 'Recording', remaining: 9 }) },
+      { kind: 'captureStateChanged', captureState: state({ state: 'Recording', remaining: 8 }) },
+      { kind: 'captureStateChanged', captureState: state({ state: 'Idle', remaining: 0, recordedTicks: 10 }) },
+    ]);
+    const captured = useProfilerSessionStore.getState().captureState;
+    expect(captured?.state).toBe('Idle');
+    expect(captured?.recordedTicks).toBe(10);
+  });
+
+  it('survives a batch that also carries other delta kinds', () => {
+    useProfilerSessionStore.getState().applyLiveBatch([
+      { kind: 'captureStateChanged', captureState: state({ state: 'Recording', remaining: 3 }) },
+      { kind: 'heartbeat', status: 'connected' },
+    ]);
+    expect(useProfilerSessionStore.getState().captureState?.remaining).toBe(3);
+    expect(useProfilerSessionStore.getState().connectionStatus).toBe('connected');
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useSessionStore.live.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useSessionStore.live.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { SessionDto } from '@/api/generated/model';
+import { isLiveStreamSession, useSessionStore } from '@/stores/useSessionStore';
+
+/**
+ * P5 — the session fields that make a paused database watchable, and the predicate that decides whether anything
+ * subscribes to the live stream.
+ */
+const BASE = {
+  sessionId: 'sess-A',
+  kind: 'Open',
+  state: 'Ready',
+  filePath: 'C:/db/world.typhon',
+} as SessionDto;
+
+afterEach(() => useSessionStore.getState().clearSession());
+
+describe('setSession — watch fields', () => {
+  it('carries the advertised endpoint and the watching flag', () => {
+    useSessionStore.getState().setSession({
+      ...BASE,
+      isPaused: true,
+      profilerEndpoint: 'localhost:9100',
+      isWatchingLive: true,
+    });
+
+    const s = useSessionStore.getState();
+    expect(s.profilerEndpoint).toBe('localhost:9100');
+    expect(s.isWatchingLive).toBe(true);
+  });
+
+  /**
+   * An older server, or any session with no holder, sends neither field. They must land as "not watchable" rather than
+   * undefined — the banner tests `profilerEndpoint` for null, and `undefined` would render a button pointing nowhere.
+   */
+  it('defaults to not-watchable when the server sends neither field', () => {
+    useSessionStore.getState().setSession(BASE);
+
+    const s = useSessionStore.getState();
+    expect(s.profilerEndpoint).toBeNull();
+    expect(s.isWatchingLive).toBe(false);
+  });
+
+  it('clears both on clearSession', () => {
+    useSessionStore.getState().setSession({ ...BASE, profilerEndpoint: 'localhost:9100', isWatchingLive: true });
+    useSessionStore.getState().clearSession();
+
+    const s = useSessionStore.getState();
+    expect(s.profilerEndpoint).toBeNull();
+    expect(s.isWatchingLive).toBe(false);
+  });
+});
+
+describe('isLiveStreamSession', () => {
+  it('is true for an attach session', () => {
+    expect(isLiveStreamSession({ kind: 'attach', isWatchingLive: false })).toBe(true);
+  });
+
+  // The P5 case: an Open session watching its holder's engine has a live stream, and gating on kind is exactly what
+  // left it without one — no capture state, therefore no Record control, with the whole server side already working.
+  it('is true for an Open session that is watching', () => {
+    expect(isLiveStreamSession({ kind: 'open', isWatchingLive: true })).toBe(true);
+  });
+
+  it('is false for an Open session that is not watching — that endpoint 409s with no runtime to serve', () => {
+    expect(isLiveStreamSession({ kind: 'open', isWatchingLive: false })).toBe(false);
+  });
+
+  it('is false when there is no session at all', () => {
+    expect(isLiveStreamSession({ kind: 'none', isWatchingLive: false })).toBe(false);
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useProfilerSessionStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useProfilerSessionStore.ts
@@ -64,7 +64,27 @@ export type LiveStreamPayload =
   | { kind: 'threadInfoAdded'; threadInfo: LiveThreadInfo }
   | { kind: 'globalMetricsUpdated'; globalMetrics: GlobalMetricsDto }
   | { kind: 'heartbeat'; status: 'connecting' | 'connected' | 'reconnecting' | 'disconnected' }
-  | { kind: 'shutdown'; status: string };
+  | { kind: 'shutdown'; status: string }
+  | { kind: 'captureStateChanged'; captureState: CaptureState };
+
+/**
+ * On-demand tick capture state (#805). Mirrors the server's `CaptureStateDto`.
+ *
+ * `state` is `Idle` (cherry-pick with no window open), `Recording` (a bounded window is running) or `Everything`
+ * (unbounded — the behaviour every attach session had before #805).
+ */
+export interface CaptureState {
+  state: 'Idle' | 'Recording' | 'Everything';
+  remaining: number;
+  recordedTicks: number;
+  mode: 'Everything' | 'CherryPick';
+  /** False when the engine runs without gauges: the timeline is then numbered from the attach point, not simulation start. */
+  tickNumbersAbsolute: boolean;
+  /** True if a `TickStart` was lost, so reported tick numbers can no longer be trusted. */
+  tickNumberingSuspect: boolean;
+  bytesReceived: number;
+  bytesRetained: number;
+}
 
 /** Live connection status — mirrors the server's `AttachSessionRuntime.ConnectionStatus`. */
 export type ConnectionStatus = 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
@@ -82,6 +102,8 @@ interface ProfilerSessionStoreState {
   isLive: boolean;
   /** Live connection status; null when no live session is active. */
   connectionStatus: ConnectionStatus | null;
+  /** On-demand tick capture state (#805); null until the first `captureStateChanged` frame, which the stream sends on connect. */
+  captureState: CaptureState | null;
   /**
    * Reason string carried by the server's `shutdown` SSE event (e.g. `"init_mismatch"` when a reconnect's Init
    * signature differs from the original session). Null for transient drops where the server emits no reason.
@@ -178,6 +200,7 @@ export const useProfilerSessionStore = create<ProfilerSessionStoreState>()((set)
 
   isLive: false,
   connectionStatus: null,
+  captureState: null,
   disconnectReason: null,
   latestTickNumber: 0,
   liveThreadInfos: new Map(),
@@ -244,6 +267,7 @@ export const useProfilerSessionStore = create<ProfilerSessionStoreState>()((set)
       let connectionStatus = s.connectionStatus;
       let disconnectReason = s.disconnectReason;
       let latestTickNumber = s.latestTickNumber;
+      let captureState = s.captureState;
 
       let pendingTicks: TickSummaryDto[] | null = null;
       let pendingChunks: ChunkManifestEntryDto[] | null = null;
@@ -276,6 +300,10 @@ export const useProfilerSessionStore = create<ProfilerSessionStoreState>()((set)
           case 'globalMetricsUpdated':
             // Last-wins — only the final metrics in the batch matter.
             pendingMetrics = ev.globalMetrics;
+            break;
+          case 'captureStateChanged':
+            // Last-wins: the state is a snapshot, not a delta, so intermediate frames in one batch are already stale.
+            captureState = ev.captureState;
             break;
           case 'threadInfoAdded': {
             const existing = (pendingThreadInfos ?? liveThreadInfos).get(ev.threadInfo.threadSlot);
@@ -318,7 +346,7 @@ export const useProfilerSessionStore = create<ProfilerSessionStoreState>()((set)
         liveThreadInfos = pendingThreadInfos;
       }
 
-      return { metadata, liveThreadInfos, connectionStatus, disconnectReason, latestTickNumber };
+      return { metadata, liveThreadInfos, connectionStatus, disconnectReason, latestTickNumber, captureState };
     }),
 
   setSlotVisibility: (slot, visible) =>
@@ -405,6 +433,7 @@ export const useProfilerSessionStore = create<ProfilerSessionStoreState>()((set)
       buildError: null,
       isLive: false,
       connectionStatus: null,
+      captureState: null,
       disconnectReason: null,
       latestTickNumber: 0,
       liveThreadInfos: new Map(),

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useSessionStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useSessionStore.ts
@@ -39,6 +39,16 @@ interface SessionStoreState {
   isPaused: boolean;
   /** Human-readable explanation for the paused banner — names the holding process. Null when not paused. */
   pausedReason: string | null;
+  /**
+   * The profiler endpoint the holding process advertises in the database's `db.lock`, or null when it advertises none.
+   *
+   * Non-null is the whole condition for offering *Watch live*: the process that took the database is a Typhon app with
+   * a live port open. A pause caused by an editor, a backup or an older build reports null, and offering to watch that
+   * would only produce a connection refused.
+   */
+  profilerEndpoint: string | null;
+  /** True while this session is watching that endpoint. Server-owned, so it survives a reload and a second tab. */
+  isWatchingLive: boolean;
   setSession: (dto: SessionDto) => void;
   clearSession: () => void;
 }
@@ -57,9 +67,13 @@ export const useSessionStore = create<SessionStoreState>()((set) => ({
   activeProfileId: null,
   isPaused: false,
   pausedReason: null,
+  profilerEndpoint: null,
+  isWatchingLive: false,
   setSession: (dto) =>
     set({
       kind: (dto.kind?.toLowerCase() ?? 'open') as SessionKind,
+      profilerEndpoint: (dto.profilerEndpoint as string | null | undefined) ?? null,
+      isWatchingLive: dto.isWatchingLive === true,
       capabilities: ((dto.capabilities as string[] | null | undefined) ?? []) as SessionCapability[],
       activeProfileId: (dto.activeProfileId as string | null | undefined) ?? null,
       isPaused: dto.isPaused === true,
@@ -89,6 +103,8 @@ export const useSessionStore = create<SessionStoreState>()((set) => ({
       activeProfileId: null,
       isPaused: false,
       pausedReason: null,
+      profilerEndpoint: null,
+      isWatchingLive: false,
     }),
 }));
 
@@ -120,9 +136,33 @@ export const useSessionCapability = (capability: SessionCapability): boolean =>
  * The attach clause is not simply `kind !== 'attach'` any more (#621): an attach session that saved a replay and
  * attached it back IS reading a file, and the surfaces gated here work for it. `activeProfileId` is exactly the
  * "a capture is attached" signal, so the test states the real condition instead of approximating it by kind.
+ *
+ * P5 removed the kind clause entirely. It read "an Open session is always file-backed", which was true only while
+ * `open` implied a database and nothing live. A paused Open session watching its holder has the profiler capability
+ * and **no file at all** — it would have been reported as trace-backed, offering Call Tree scoping (CPU sampling is
+ * file-mode only) against a live socket with nothing on disk to scope. Since #613 deleted the standalone trace
+ * session, every file-backed session reaches its capture as an attached profile, so `activeProfileId` alone is the
+ * condition for all kinds.
  */
 export const useTraceBackedSession = (): boolean =>
-  useSessionStore((s) => s.capabilities.includes('profiler') && (s.kind !== 'attach' || s.activeProfileId !== null));
+  useSessionStore((s) => s.capabilities.includes('profiler') && s.activeProfileId !== null);
+
+/**
+ * True when the session has a live profiler stream to subscribe to — the counterpart of
+ * {@link useTraceBackedSession}, and deliberately NOT `kind === 'attach'`.
+ *
+ * A paused Open session watching its holder's engine is live too (P5). The stream endpoint and the SSE hook are both
+ * kind-agnostic — the server gates on `ILiveProfilerHost`, which an `OpenSession` implements once it is watching — so
+ * the only thing that ever made live a property of Attach was call sites asking about `kind`. That is what left the
+ * Record control missing on a watching database session while the whole server side was ready for it.
+ *
+ * Written as a plain predicate over the two fields so it can be unit-tested without rendering a panel.
+ */
+export const isLiveStreamSession = (state: Pick<SessionStoreState, 'kind' | 'isWatchingLive'>): boolean =>
+  state.kind === 'attach' || state.isWatchingLive;
+
+/** Hook form of {@link isLiveStreamSession}, for components. */
+export const useLiveStreamSession = (): boolean => useSessionStore(isLiveStreamSession);
 
 /**
  * True when a database-backed panel should show a *paused* state rather than an error (#621).

--- a/tools/Typhon.Workbench/Controllers/ProfilerController.cs
+++ b/tools/Typhon.Workbench/Controllers/ProfilerController.cs
@@ -53,11 +53,14 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
             return NotReady();
         }
 
-        if (session is AttachSession attach)
+        // Checked AFTER the profile above, so an attached capture keeps precedence over the live stream — that is the
+        // existing Attach behaviour and it is also what a watching database session wants: the profile is what the user
+        // put in the foreground.
+        if (session is ILiveProfilerHost { LiveRuntime: { } live })
         {
-            if (attach.Runtime.Metadata != null)
+            if (live.Metadata != null)
             {
-                return Ok(attach.Runtime.Metadata);
+                return Ok(live.Metadata);
             }
             // Init frame hasn't arrived yet — client retries.
             return NotReady();
@@ -96,9 +99,9 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
     {
         var session = HttpContext.Items["Session"];
 
-        if (session is AttachSession attach)
+        if (session is ILiveProfilerHost { LiveRuntime: { } live })
         {
-            return Ok(attach.Runtime.SourceLocationManifest);
+            return Ok(live.SourceLocationManifest);
         }
 
         if (TryGetProfilerRuntime(session, out var profileRuntime))
@@ -132,9 +135,9 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
             return Ok(runtime.CpuSampleData.Manifest);
         }
 
-        if (session is AttachSession)
+        if (session is ILiveProfilerHost { LiveRuntime: not null })
         {
-            // CPU sampling is file-mode only in v1 — a live attach carries no sample data (design §2, §9 risk 2).
+            // CPU sampling is file-mode only in v1 — a live stream carries no sample data (design §2, §9 risk 2).
             return Ok(CpuFrameManifestDto.Empty);
         }
 
@@ -182,7 +185,7 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
             return Ok(tree);
         }
 
-        if (session is AttachSession)
+        if (session is ILiveProfilerHost { LiveRuntime: not null })
         {
             return Ok(CallTreeResponseDto.Empty);
         }
@@ -222,7 +225,7 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
                 cpu.Samples, cpu.Stacks, windows, scope, runtime.TimestampFrequency, request?.BinCount ?? 0, cpu.ThreadRuns));
         }
 
-        if (session is AttachSession)
+        if (session is ILiveProfilerHost { LiveRuntime: not null })
         {
             return Ok(SampleDensityDto.Empty);
         }
@@ -248,6 +251,121 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
         attach.Runtime.RequestDisconnect();
         return NoContent();
     }
+
+    /// <summary>
+    /// Arm an on-demand capture window (#805) — record the next <c>tickCount</c> ticks of a live attach session in full.
+    /// Pass <c>0</c> to stop a capture already in flight.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Takes effect at the next tick boundary, never mid-tick, so a window can never contain a partial tick. The unit is
+    /// deliberately ticks rather than milliseconds: the timeline draws one bar per tick, and the scheduler throttles its
+    /// tick rate under overload — exactly when someone is recording — so a duration would buy an unpredictable number of
+    /// bars.
+    /// </para>
+    /// <para>
+    /// Attach-only. A Trace session is already a finished capture, and an Open session has no live record stream.
+    /// </para>
+    /// </remarks>
+    [HttpPost("capture")]
+    public ActionResult<CaptureStateDto> Capture(Guid sessionId, [FromBody] CaptureRequest request)
+    {
+        var session = HttpContext.Items["Session"];
+        if (session is not ILiveProfilerHost { LiveRuntime: { } runtime })
+        {
+            return ConflictKindMismatch(NotWatchingDetail);
+        }
+
+        var tickCount = request?.TickCount ?? 0;
+        if (tickCount < 0)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "invalid_tick_count",
+                Detail = "tickCount must be zero (stop) or positive.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        try
+        {
+            return Ok(runtime.Arm(tickCount));
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Attached in capture-everything mode — arming a window would contradict the mode chosen at attach time.
+            return Conflict(new ProblemDetails
+            {
+                Title = "capture_mode_mismatch",
+                Detail = ex.Message,
+                Status = StatusCodes.Status409Conflict,
+            });
+        }
+    }
+
+    /// <summary>Current on-demand capture state for a session that is watching a live engine (#805).</summary>
+    [HttpGet("capture")]
+    public ActionResult<CaptureStateDto> GetCapture(Guid sessionId)
+    {
+        var session = HttpContext.Items["Session"];
+        if (session is not ILiveProfilerHost { LiveRuntime: { } runtime })
+        {
+            return ConflictKindMismatch(NotWatchingDetail);
+        }
+        return Ok(runtime.CaptureState);
+    }
+
+    /// <summary>
+    /// Begin watching the live engine that holds this database (#805 / unified mode). Valid on a <b>paused</b> Open
+    /// session whose holder advertises a profiler endpoint in <c>db.lock</c>.
+    /// </summary>
+    /// <remarks>
+    /// The endpoint is never taken from the client: it comes from the lock file the holder itself wrote. A session can
+    /// therefore only ever watch the application that actually holds its database, which is what keeps this from
+    /// becoming a general "connect anywhere" hole on a session-scoped route.
+    /// </remarks>
+    [HttpPost("watch")]
+    public async Task<ActionResult<CaptureStateDto>> StartWatching(Guid sessionId, [FromBody] WatchRequest request, CancellationToken ct)
+    {
+        var session = HttpContext.Items["Session"];
+        if (session is not OpenSession open)
+        {
+            return ConflictKindMismatch("Watching is started from a database session. An Attach session is already watching.");
+        }
+
+        var endpoint = open.PausedBy?.ProfilerEndpoint;
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            return Conflict(new ProblemDetails
+            {
+                Title = "no_profiler_advertised",
+                Detail = open.IsPaused
+                    ? "The process holding this database does not advertise a live profiler. Run it with a live port to watch it."
+                    : "This database is not held by another process, so there is nothing to watch. Its captures are in the Profiles list.",
+                Status = StatusCodes.Status409Conflict,
+            });
+        }
+
+        var mode = request?.CherryPick == false ? CaptureMode.Everything : CaptureMode.CherryPick;
+        var runtime = await AttachSessionRuntime.StartAsync(open.Id, endpoint, _logger, ct, mode);
+        open.StartWatching(runtime);
+        return Ok(runtime.CaptureState);
+    }
+
+    /// <summary>Stop watching. Idempotent — 204 whether or not anything was being watched.</summary>
+    [HttpDelete("watch")]
+    public IActionResult StopWatching(Guid sessionId)
+    {
+        var session = HttpContext.Items["Session"];
+        if (session is OpenSession open)
+        {
+            open.StopWatching();
+        }
+        return NoContent();
+    }
+
+    private const string NotWatchingDetail =
+        "This session is not watching a live engine. Open the database while your application holds it, then start watching.";
 
     /// <summary>
     /// Snapshot the current live attach session into a self-contained <c>.typhon-replay</c> file. The output is byte-format-identical to
@@ -278,7 +396,7 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
         string resolved;
         if (string.IsNullOrWhiteSpace(request?.Path))
         {
-            resolved = ResolveDefaultCapturePath();
+            resolved = Sessions.CaptureStorage.ResolveDefaultCapturePath();
         }
         else
         {
@@ -368,10 +486,12 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
     {
         // #289 — both Trace and Attach sessions implement IChunkProvider, so this method handles both modes uniformly.
         var session = HttpContext.Items["Session"];
-        // Attach keeps its own runtime type; everything else resolves through the capability helper (#617).
+        // Attach keeps its own runtime type; everything else resolves through the capability helper (#617), falling back
+        // to a live stream for a database session that is watching its application and has no capture in the foreground.
         IChunkProvider provider = session is AttachSession attach
             ? attach.Runtime
-            : TryGetProfilerRuntime(session, out var chunkRuntime) ? chunkRuntime : null;
+            : TryGetProfilerRuntime(session, out var chunkRuntime) ? chunkRuntime
+            : (session as ILiveProfilerHost)?.LiveRuntime;
         if (provider == null)
         {
             Response.StatusCode = StatusCodes.Status409Conflict;
@@ -452,10 +572,12 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
         CancellationToken ct)
     {
         var session = HttpContext.Items["Session"];
-        // Attach keeps its own runtime type; everything else resolves through the capability helper (#617).
+        // Attach keeps its own runtime type; everything else resolves through the capability helper (#617), falling back
+        // to a live stream for a database session that is watching its application and has no capture in the foreground.
         IChunkProvider provider = session is AttachSession attach
             ? attach.Runtime
-            : TryGetProfilerRuntime(session, out var chunkRuntime) ? chunkRuntime : null;
+            : TryGetProfilerRuntime(session, out var chunkRuntime) ? chunkRuntime
+            : (session as ILiveProfilerHost)?.LiveRuntime;
         if (provider == null)
         {
             return Conflict();
@@ -559,27 +681,6 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
     /// <c>$XDG_DATA_HOME/typhon/workbench/captures/</c> on POSIX), guarantees the directory exists, and stamps a
     /// monotone filename so repeated captures don't collide. Returns the resolved absolute path.
     /// </summary>
-    private static string ResolveDefaultCapturePath()
-    {
-        string root;
-        if (OperatingSystem.IsWindows())
-        {
-            root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        }
-        else
-        {
-            // XDG-equivalent on POSIX — defaults to ~/.local/share if XDG_DATA_HOME is unset.
-            var xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-            root = !string.IsNullOrWhiteSpace(xdg)
-                ? xdg
-                : System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
-        }
-        var capturesDir = System.IO.Path.Combine(root, "Typhon", "Workbench", "captures");
-        System.IO.Directory.CreateDirectory(capturesDir);
-        var stamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ", System.Globalization.CultureInfo.InvariantCulture);
-        return System.IO.Path.Combine(capturesDir, $"typhon-capture-{stamp}.typhon-replay");
-    }
-
     private static List<TraceEventDto> ApplyFilters(List<TraceEventDto> source, HashSet<int> kinds, int? tick)
     {
         var result = new List<TraceEventDto>();
@@ -721,7 +822,11 @@ public sealed partial class ProfilerController : WorkbenchControllerBase
         {
             return attach.Runtime.QueryCatalog;
         }
-        return TryGetProfilerRuntime(session, out var runtime) && runtime.IsReady ? runtime.QueryCatalog : null;
+        if (TryGetProfilerRuntime(session, out var runtime) && runtime.IsReady)
+        {
+            return runtime.QueryCatalog;
+        }
+        return (session as ILiveProfilerHost)?.LiveRuntime?.QueryCatalog;
     }
 
     /// <summary>

--- a/tools/Typhon.Workbench/Controllers/SessionsController.cs
+++ b/tools/Typhon.Workbench/Controllers/SessionsController.cs
@@ -74,10 +74,14 @@ public sealed partial class SessionsController : ControllerBase
             // Only the first can name the holder from the exception; for the second we read db.lock if it happens to be
             // there, and otherwise say plainly that we do not know who. Failing hard on the second while pausing on the
             // first would make the same situation behave differently depending on which race the caller lost.
+            // The endpoint is read from the lock rather than taken from the refusal — see DatabaseHolder.ProfilerEndpoint
+            // for why that is safe for an address and not for an identity. It is what turns "someone else has your
+            // database" into "…and you can watch them", which is the whole point of opening paused.
+            var endpoint = DatabaseHolder.ReadProfilerEndpoint(resolvedFile);
             var holder = ex is DatabaseLockedException locked
-                ? new DatabaseHolder(locked.OwnerPid, locked.OwnerMachine, locked.StartedAt)
+                ? new DatabaseHolder(locked.OwnerPid, locked.OwnerMachine, locked.StartedAt, endpoint)
                 : DatabaseLockFile.TryReadHolder(resolvedFile, out var pid, out var machine, out var startedAt)
-                    ? new DatabaseHolder(pid, machine, startedAt)
+                    ? new DatabaseHolder(pid, machine, startedAt, endpoint)
                     : null;
             var pausedSession = new OpenSession(Guid.NewGuid(), resolvedFile, holder, requestedSchemaDllPaths);
             _sessions.Create(pausedSession);
@@ -128,7 +132,8 @@ public sealed partial class SessionsController : ControllerBase
         // AttachSessionRuntime.StartAsync does 3 × 2 s upfront TCP retry; throws WorkbenchException(503) on total failure.
         // Session id is generated up front so the live cache temp file path matches the public sessionId.
         var sessionId = Guid.NewGuid();
-        var runtime = await AttachSessionRuntime.StartAsync(sessionId, request.EndpointAddress, _logger, ct);
+        var captureMode = request.CherryPick ? CaptureMode.CherryPick : CaptureMode.Everything;
+        var runtime = await AttachSessionRuntime.StartAsync(sessionId, request.EndpointAddress, _logger, ct, captureMode);
 
         var session = new AttachSession(sessionId, request.EndpointAddress, runtime);
         _sessions.Create(session);
@@ -222,10 +227,17 @@ public sealed partial class SessionsController : ControllerBase
     private static SessionDto ToDto(WbSession s)
     {
         var dto = ToDtoCore(s);
+        // Both watch fields are applied HERE rather than in ToDtoCore's branches, for the same reason Capabilities is:
+        // ToDtoCore returns from four places and a field set in three of them is a bug that presents as a button that
+        // silently never appears.
+        var open = s as OpenSession;
         return dto with
         {
             Capabilities = [.. s.Capabilities],
             ActiveProfileId = s.ActiveProfileId,
+            // Null unless a holder is advertising a profiler port — the client's whole test for "can this be watched".
+            ProfilerEndpoint = open?.PausedBy?.ProfilerEndpoint,
+            IsWatchingLive = open?.IsWatchingLive ?? false,
         };
     }
 

--- a/tools/Typhon.Workbench/Dtos/Profiler/CaptureStateDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Profiler/CaptureStateDto.cs
@@ -1,0 +1,49 @@
+namespace Typhon.Workbench.Dtos.Profiler;
+
+/// <summary>
+/// On-demand tick capture state for a live attach session (#805).
+/// </summary>
+/// <param name="State">
+/// <c>Idle</c> — cherry-pick mode with no window open, only the per-tick skeleton retained.
+/// <c>Recording</c> — a bounded window is open.
+/// <c>Everything</c> — unbounded capture, the pre-#805 behaviour.
+/// </param>
+/// <param name="Remaining">Ticks still to record in the current window; 0 when idle or unbounded.</param>
+/// <param name="RecordedTicks">Ticks whose detail has been recorded across the whole session. Drives the auto-save guard.</param>
+/// <param name="Mode">The capture mode chosen at attach time — <c>Everything</c> or <c>CherryPick</c>.</param>
+/// <param name="TickNumbersAbsolute">
+/// True once a gauge record has established the mapping from derived to true simulation tick numbers. False means the
+/// engine is running without gauges, so the timeline is numbered relative to attach and the UI must say so.
+/// </param>
+/// <param name="TickNumberingSuspect">
+/// True if the absolute tick number stopped agreeing with the derived count — the signature of a lost <c>TickStart</c>.
+/// Reported rather than silently corrected: a renumbered timeline that looks plausible is worse than one that admits it.
+/// </param>
+/// <param name="BytesReceived">Raw record bytes received from the engine, before filtering.</param>
+/// <param name="BytesRetained">Record bytes actually retained. The ratio is the feature's measured value.</param>
+public record CaptureStateDto(
+    string State,
+    int Remaining,
+    long RecordedTicks,
+    string Mode,
+    bool TickNumbersAbsolute,
+    bool TickNumberingSuspect,
+    long BytesReceived,
+    long BytesRetained);
+
+/// <summary>Request body for <c>POST /api/sessions/{id}/profiler/capture</c>.</summary>
+/// <param name="TickCount">
+/// How many consecutive ticks to record in full, starting at the next tick boundary. Zero stops an in-flight capture.
+/// The unit is deliberately ticks and not milliseconds: the timeline draws one bar per tick, and Typhon throttles its
+/// tick rate under overload — precisely when someone is recording — so a duration would buy an unpredictable number of bars.
+/// </param>
+public record CaptureRequest(int TickCount);
+
+/// <summary>Request body for <c>POST /api/sessions/{id}/profiler/watch</c>.</summary>
+/// <param name="CherryPick">
+/// Defaults to <c>true</c> here, the opposite of the endpoint-only Attach flow. Watching is entered from a database
+/// whose application is mid-run: you are there to grab a window around something you are about to see, and the complete
+/// record is already being written to the database's own <c>profilings/</c> by the engine. Recording everything a
+/// second time, over TCP, would duplicate an artifact you are guaranteed to get anyway.
+/// </param>
+public record WatchRequest(bool CherryPick = true);

--- a/tools/Typhon.Workbench/Dtos/Profiler/LiveStreamEventDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Profiler/LiveStreamEventDto.cs
@@ -25,7 +25,8 @@ public record LiveStreamEventDto(
     ChunkManifestEntryDto ChunkEntry = null,
     GlobalMetricsDto GlobalMetrics = null,
     ThreadInfoDto ThreadInfo = null,
-    string Status = null);
+    string Status = null,
+    CaptureStateDto CaptureState = null);
 
 /// <summary>
 /// One (slot → thread name + kind) mapping. Emitted via <c>threadInfoAdded</c> SSE delta as the engine's worker

--- a/tools/Typhon.Workbench/Dtos/Sessions/CreateAttachSessionRequest.cs
+++ b/tools/Typhon.Workbench/Dtos/Sessions/CreateAttachSessionRequest.cs
@@ -1,3 +1,16 @@
 namespace Typhon.Workbench.Dtos.Sessions;
 
-public record CreateAttachSessionRequest(string EndpointAddress);
+/// <summary>Request body for <c>POST /api/sessions/attach</c>.</summary>
+/// <param name="EndpointAddress">The engine's live profiler endpoint, e.g. <c>localhost:9100</c>.</param>
+/// <param name="CherryPick">
+/// On-demand tick capture (#805). <c>false</c> (the default) records everything for as long as the session lives —
+/// the behaviour of every attach session before #805, preserved bit-for-bit for existing callers. <c>true</c> starts
+/// the session idle: only the per-tick skeleton is retained until the operator arms a window with
+/// <c>POST /api/sessions/{id}/profiler/capture</c>.
+/// </param>
+/// <remarks>
+/// The choice is made per attach rather than remembered, because the two modes answer different questions and the
+/// right answer is not sticky: "show me everything this run does" and "let me grab the 100 ticks around that spike"
+/// are both legitimate on the same engine minutes apart.
+/// </remarks>
+public record CreateAttachSessionRequest(string EndpointAddress, bool CherryPick = false);

--- a/tools/Typhon.Workbench/Dtos/Sessions/SessionDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Sessions/SessionDto.cs
@@ -19,6 +19,12 @@ public record SessionDto(
     // #617 — what the session can DO, so the client stops inferring it from Kind. An Open session gains and loses
     // "profiler" as profiles are attached and detached, which no kind enum can express.
     string[] Capabilities = null,
-    Guid? ActiveProfileId = null);
+    Guid? ActiveProfileId = null,
+    // P5 — live attach as a capability of a paused Open session. The endpoint comes from the holder's `db.lock`, so a
+    // non-null value means "the process holding this database is advertising a profiler port": exactly the condition
+    // under which offering to watch it makes sense. Without this the client cannot tell a watchable pause from an
+    // ordinary one, and `DatabaseHolder.IsWatchable` was server-only.
+    string ProfilerEndpoint = null,
+    bool IsWatchingLive = false);
 
 public record SessionDiagnosticDto(string ComponentName, string Kind, string Detail);

--- a/tools/Typhon.Workbench/Services/ProfileCatalog.cs
+++ b/tools/Typhon.Workbench/Services/ProfileCatalog.cs
@@ -66,8 +66,50 @@ public static class ProfileCatalog
             rows.Add(ReadRow(path, info, attached.Id == Guid.Empty ? null : attached.Id, attached.IsActive, policy.IsPinned(info.Name), databaseId));
         }
 
+        // Cherry-picked windows saved by a watching session (#805) land here too, as self-contained .typhon-replay
+        // caches. They are captures of this database by every meaning that matters — recorded from its engine, written
+        // to its profilings/ — and listing only .typhon-trace would leave the operator's deliberately-recorded ticks
+        // invisible in the one place built for finding captures. `TraceSessionRuntime` already opens them.
+        foreach (var path in Directory.EnumerateFiles(profilings, "*" + CaptureStorage.ReplayExtension))
+        {
+            var info = new FileInfo(path);
+            attachedByName.TryGetValue(info.Name, out var attached);
+            rows.Add(ReadRow(path, info, attached.Id == Guid.Empty ? null : attached.Id, attached.IsActive, policy.IsPinned(info.Name), databaseId));
+        }
+
         rows.Sort(static (a, b) => b.CreatedUtcTicks.CompareTo(a.CreatedUtcTicks));
         return new ProfileListDto([.. rows], databaseTsn, profilings);
+    }
+
+    /// <summary>
+    /// Reads a capture's <see cref="TraceFileHeader"/>, whichever of the two on-disk shapes it has.
+    /// </summary>
+    /// <remarks>
+    /// A <c>.typhon-trace</c> starts with the header. A <c>.typhon-replay</c> is a self-contained <b>cache</b> whose
+    /// <c>SourceMetadata</c> section carries the same header verbatim, in the engine's wire format — so the same
+    /// projection works once the bytes are handed to a <see cref="TraceFileReader"/>, exactly as
+    /// <see cref="TraceFileCacheReader.SourceMetadataBytes"/> documents. A replay that is not self-contained has no
+    /// header to read and is thrown out to the unreadable row, which is the honest outcome: the row still shows the
+    /// file exists, and nothing invents columns it cannot know.
+    /// </remarks>
+    private static TraceFileHeader ReadCaptureHeader(string path)
+    {
+        using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        if (!string.Equals(Path.GetExtension(path), CaptureStorage.ReplayExtension, StringComparison.OrdinalIgnoreCase))
+        {
+            using var traceReader = new TraceFileReader(stream);
+            return traceReader.ReadHeader();
+        }
+
+        using var cacheReader = new TraceFileCacheReader(stream);
+        if (!cacheReader.IsSelfContained || cacheReader.SourceMetadataBytes.IsEmpty)
+        {
+            throw new InvalidDataException($"Replay '{Path.GetFileName(path)}' carries no embedded source metadata.");
+        }
+
+        using var metadata = new MemoryStream(cacheReader.SourceMetadataBytes.ToArray(), writable: false);
+        using var embeddedReader = new TraceFileReader(metadata);
+        return embeddedReader.ReadHeader();
     }
 
     /// <summary>Reads one capture's header into a row, degrading to an unreadable row rather than throwing.</summary>
@@ -79,9 +121,7 @@ public static class ProfileCatalog
     {
         try
         {
-            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = new TraceFileReader(stream);
-            var h = reader.ReadHeader();
+            var h = ReadCaptureHeader(path);
 
             return new ProfileDto(
                 FileName: info.Name,
@@ -139,9 +179,11 @@ public static class ProfileCatalog
         reason = null;
         try
         {
-            using var stream = File.Open(capturePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = new TraceFileReader(stream);
-            var h = reader.ReadHeader();
+            // Same projection the list uses, so a capture that appears in the Profiles list can always be attached from
+            // it. Reading with TraceFileReader unconditionally would reject every .typhon-replay as unreadable — the
+            // list would show the operator their recorded window and then refuse to open it, which is worse than not
+            // listing it at all.
+            var h = ReadCaptureHeader(capturePath);
 
             if (h.DatabaseId == Guid.Empty || databaseId == Guid.Empty || h.DatabaseId == databaseId)
             {
@@ -152,7 +194,7 @@ public static class ProfileCatalog
             reason = $"This capture was recorded against database {h.DatabaseId:D}"
                 + (string.IsNullOrEmpty(recorded) ? "" : $" ('{recorded}')")
                 + $", not the one this session has open ({databaseId:D}). It is sitting in this bundle, but it does not belong to it — "
-                + "open it as a standalone trace session instead.";
+                + "open the database it was recorded against and attach it there.";
             return false;
         }
         catch (Exception ex) when (ex is IOException or InvalidDataException or UnauthorizedAccessException)

--- a/tools/Typhon.Workbench/Sessions/AttachSession.cs
+++ b/tools/Typhon.Workbench/Sessions/AttachSession.cs
@@ -6,11 +6,15 @@ namespace Typhon.Workbench.Sessions;
 /// Per-session handle for a live Typhon app attached over TCP. Owns an <see cref="AttachSessionRuntime"/> that manages
 /// the socket + frame-read loop + SSE subscriber fan-out.
 /// </summary>
-public sealed class AttachSession : ISession, IDisposable
+public sealed class AttachSession : ISession, ILiveProfilerHost, IDisposable
 {
     public Guid Id { get; }
     public string EndpointAddress { get; }
     public AttachSessionRuntime Runtime { get; }
+
+    /// <inheritdoc />
+    /// <remarks>An attach session exists to watch; its live runtime is never null for the session's lifetime.</remarks>
+    public AttachSessionRuntime LiveRuntime => Runtime;
 
     public SessionKind Kind => SessionKind.Attach;
     public SessionState State => SessionState.Attached;

--- a/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.Capture.cs
+++ b/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.Capture.cs
@@ -1,0 +1,447 @@
+using System.Buffers.Binary;
+using Typhon.Profiler;
+using Typhon.Workbench.Dtos.Profiler;
+
+namespace Typhon.Workbench.Sessions;
+
+/// <summary>
+/// On-demand tick capture (#805) — the record filter that sits between the engine's Block frames and the
+/// <see cref="IncrementalCacheBuilder"/>, plus the absolute-tick-number offset derived from the same walk.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the filter lives here and not in the engine.</b> Gating at the producer (<c>TyphonEvent.BeginPrologue</c> plus
+/// the trace-event source generator) would additionally save the 25–50 ns/span the application's worker threads pay and
+/// remove the ring/spillover pressure that makes high-rate workloads drop records. It was rejected on blast radius: it
+/// needs a bidirectional control channel, a receive thread on a port bound to <c>IPAddress.Any</c>, and a change to a
+/// source generator feeding 204 event kinds. Filtering here changes no engine code and cannot regress a non-Workbench
+/// user. See <c>claude/design/Profiler/12-on-demand-tick-capture.md</c> §3.
+/// </para>
+/// <para>
+/// <b>Threading.</b> Every field here except <see cref="_pendingArmTicks"/> is touched only from the read-loop task, which
+/// is single-threaded per session. <see cref="_pendingArmTicks"/> is written by HTTP request threads and consumed at a
+/// tick boundary, so it moves through <see cref="Interlocked"/>.
+/// </para>
+/// </remarks>
+public sealed partial class AttachSessionRuntime
+{
+    /// <summary>Sentinel for "capture everything" — the pre-#805 behaviour, and what <see cref="CaptureMode.Everything"/> installs.</summary>
+    internal const int AlwaysOnTicks = int.MaxValue;
+
+    /// <summary>Sentinel meaning "no arm request outstanding". Zero is a legal request (it means disarm), so it cannot double as the sentinel.</summary>
+    private const int NoPendingArm = -1;
+
+    /// <summary>
+    /// Kinds that pass the filter whatever the arm state, indexed by <see cref="TraceEventKind"/> ordinal.
+    /// </summary>
+    /// <remarks>
+    /// The rule, so the set can be re-derived rather than trusted: <i>keep every kind emitted at most once per tick that
+    /// feeds <c>TickSummary</c> or the viewer's structural state.</i>
+    /// <list type="bullet">
+    ///   <item><c>TickStart</c>/<c>TickEnd</c> — the tick spine. Tick numbers are not on the wire; the builder derives
+    ///   them by counting <c>TickStart</c> markers, so dropping one silently renumbers every later tick.</item>
+    ///   <item><c>SchedulerMetronomeWait</c> — a duration input <i>by side effect</i>: the builder lets its timestamp push
+    ///   <c>_currentTickLastTs</c> past <c>TickEnd</c> before sealing. Filtering it makes every idle tick's bar
+    ///   systematically shorter than every armed one — a step at the window edge that reads as "the profiler slowed my
+    ///   app down when I hit Record". Measured at 50 µs vs 90 µs on the same tick by
+    ///   <c>MockRecordFactoryTests.MetronomeWait_ExtendsTickDuration_BeyondTickEnd</c>.</item>
+    ///   <item><c>SchedulerOverloadDetector</c> — the consecutive overrun/underrun counters on the summary.</item>
+    ///   <item><c>PerTickSnapshot</c> — the gauge strip, whose capacity gauges are emitted on the FIRST snapshot only;
+    ///   filtering it while idle at session start would permanently break every gauge percentage. It also carries the
+    ///   only absolute tick number on the live wire (see <see cref="TryLearnTickOffset"/>).</item>
+    ///   <item><c>ThreadInfo</c> — slot→lane names; without them the viewer cannot lay out tracks.</item>
+    /// </list>
+    /// <c>QueueTickEnd</c> (244) is deliberately absent: it is one record per <i>(tick × active event queue)</i>, scales
+    /// with queue count, and is not a summary input.
+    /// </remarks>
+    private static readonly bool[] ExemptKinds = BuildExemptKinds();
+
+    /// <summary>Ticks still to record in the current window; <see cref="AlwaysOnTicks"/> means unbounded, 0 means idle.</summary>
+    private int _remainingTicks;
+
+    /// <summary>Arm request from an HTTP thread, consumed at the next <c>TickStart</c>. <see cref="NoPendingArm"/> when none.</summary>
+    private int _pendingArmTicks = NoPendingArm;
+
+    /// <summary>Whether the tick currently being walked is being recorded in full. Read-loop only.</summary>
+    private bool _armedForCurrentTick;
+
+    /// <summary>The capture mode chosen at attach time. Immutable for the session's lifetime.</summary>
+    private CaptureMode _captureMode = CaptureMode.Everything;
+
+    /// <summary>Count of <c>TickStart</c> markers passed downstream — mirrors the builder's own derived tick counter exactly.</summary>
+    private uint _derivedTickCount;
+
+    /// <summary>
+    /// <c>engineTick - derivedTick</c>, learned from the first <see cref="TraceEventKind.PerTickSnapshot"/>. Applied when
+    /// projecting tick numbers so the client sees true simulation ticks rather than attach-relative ones.
+    /// </summary>
+    private long _tickNumberOffset;
+
+    /// <summary>True once <see cref="_tickNumberOffset"/> has been established from a gauge record.</summary>
+    /// <remarks>
+    /// Written on the read loop, read from HTTP request threads (<see cref="CaptureState"/>) and from
+    /// <see cref="ToAbsoluteTick"/> on the chunk-fetch path. That is cross-thread publication outside any lock, so it
+    /// goes through <see cref="Volatile"/> per the engine's memory-ordering discipline — acquire/release is free on x64
+    /// and is what makes this correct on arm64 rather than accidentally so.
+    /// </remarks>
+    private bool _tickOffsetKnown;
+
+    /// <summary>Set when the offset drifts — the signature of a dropped <c>TickStart</c>. Surfaced, never silently corrected.</summary>
+    private bool _tickNumberingSuspect;
+
+    /// <summary>Total ticks whose detail was recorded across the whole session. Drives the "was anything captured?" auto-save guard.</summary>
+    private long _recordedTickCount;
+
+    /// <summary>Bytes seen before filtering, for the per-kind volume census the design calls for.</summary>
+    private long _recordBytesReceived;
+
+    /// <summary>Bytes actually handed to the builder.</summary>
+    private long _recordBytesRetained;
+
+    private static bool[] BuildExemptKinds()
+    {
+        var exempt = new bool[256];
+        exempt[(int)TraceEventKind.TickStart] = true;
+        exempt[(int)TraceEventKind.TickEnd] = true;
+        exempt[(int)TraceEventKind.SchedulerMetronomeWait] = true;
+        exempt[(int)TraceEventKind.SchedulerOverloadDetector] = true;
+        exempt[(int)TraceEventKind.PerTickSnapshot] = true;
+        exempt[(int)TraceEventKind.ThreadInfo] = true;
+        return exempt;
+    }
+
+    /// <summary>Whether a kind survives the filter regardless of arm state.</summary>
+    internal static bool IsExemptKind(TraceEventKind kind) => ExemptKinds[(int)kind];
+
+    /// <summary>Current capture state, as surfaced over HTTP and SSE.</summary>
+    public CaptureStateDto CaptureState
+    {
+        get
+        {
+            var remaining = Volatile.Read(ref _remainingTicks);
+            var pending = Volatile.Read(ref _pendingArmTicks);
+            // A request that has not reached a tick boundary yet still reads as Recording — the operator pressed Record
+            // and the window is committed; showing Idle for up to one tick would look like the click was lost.
+            var effective = pending != NoPendingArm ? pending : remaining;
+            var state = effective switch
+            {
+                AlwaysOnTicks => CaptureRunState.Everything,
+                <= 0 => CaptureRunState.Idle,
+                _ => CaptureRunState.Recording,
+            };
+            return new CaptureStateDto(
+                State: state.ToString(),
+                Remaining: effective == AlwaysOnTicks || effective < 0 ? 0 : effective,
+                RecordedTicks: Interlocked.Read(ref _recordedTickCount),
+                Mode: _captureMode.ToString(),
+                TickNumbersAbsolute: Volatile.Read(ref _tickOffsetKnown),
+                TickNumberingSuspect: Volatile.Read(ref _tickNumberingSuspect),
+                BytesReceived: Interlocked.Read(ref _recordBytesReceived),
+                BytesRetained: Interlocked.Read(ref _recordBytesRetained));
+        }
+    }
+
+    /// <summary>True if at least one tick's detail has been recorded — the auto-save guard for cherry-pick sessions.</summary>
+    public bool HasRecordedAnything => Interlocked.Read(ref _recordedTickCount) > 0;
+
+    /// <summary>The capture mode chosen when the session was created.</summary>
+    public CaptureMode Mode => _captureMode;
+
+    /// <summary>
+    /// Request that the next <paramref name="tickCount"/> ticks be recorded in full. Takes effect at the next
+    /// <c>TickStart</c>, never mid-tick, so a window can never contain a partial tick. Pass 0 to stop an in-flight
+    /// capture.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The session was attached in <see cref="CaptureMode.Everything"/>. Arming would leave the session reporting a
+    /// bounded window while its mode still said "everything" — a state the operator never asked for and the UI cannot
+    /// describe. The mode is a choice made at attach; detach and re-attach to change it.
+    /// </exception>
+    public CaptureStateDto Arm(int tickCount)
+    {
+        ThrowIfDisposed();
+        if (tickCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tickCount), "tick count must be zero (stop) or positive");
+        }
+        if (_captureMode != CaptureMode.CherryPick)
+        {
+            throw new InvalidOperationException(
+                "This session was attached in capture-everything mode. Re-attach in cherry-pick mode to record specific tick windows.");
+        }
+        Interlocked.Exchange(ref _pendingArmTicks, tickCount);
+        LogCaptureArmRequested(tickCount);
+        var state = CaptureState;
+        PublishCaptureState(state);
+        return state;
+    }
+
+    /// <summary>Fires whenever the capture state changes — SSE handlers forward it as a <c>captureStateChanged</c> delta.</summary>
+    public event Action<CaptureStateDto> CaptureStateChanged;
+
+    /// <summary>Raise the in-process event and fan the same state out to SSE subscribers.</summary>
+    private void PublishCaptureState(CaptureStateDto state = null)
+    {
+        state ??= CaptureState;
+        CaptureStateChanged?.Invoke(state);
+        BroadcastDelta(new LiveStreamEventDto(Kind: "captureStateChanged", CaptureState: state));
+    }
+
+    /// <summary>
+    /// Walk <paramref name="records"/>, keeping every record that belongs in the cache and dropping the rest.
+    /// Returns the number of bytes written into <paramref name="destination"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Filtering is <b>per record, never per block</b>. A Block frame is a timestamp-ordered merge across all thread slots
+    /// drained on a 1 ms cadence, so one block can straddle a tick boundary; dropping whole blocks would both leak
+    /// pre-arm records and lose post-arm ones.
+    /// </para>
+    /// <para>
+    /// The same walk also maintains the derived tick counter and learns the absolute-tick offset, because both need to
+    /// see exactly the records that reach the builder — deriving them anywhere else would let the two drift.
+    /// </para>
+    /// </remarks>
+    private int FilterRecords(ReadOnlySpan<byte> records, Span<byte> destination)
+    {
+        var pos = 0;
+        var written = 0;
+
+        while (pos + MinRecordSize <= records.Length)
+        {
+            var size = BinaryPrimitives.ReadUInt16LittleEndian(records[pos..]);
+            if (size < MinRecordSize || pos + size > records.Length)
+            {
+                // Malformed tail — mirror the builder's bail-out rather than inventing a different one.
+                break;
+            }
+
+            var kind = (TraceEventKind)records[pos + 2];
+
+            if (kind == TraceEventKind.TickStart)
+            {
+                OpenTick();
+            }
+
+            var keep = _armedForCurrentTick || ExemptKinds[(int)kind];
+            if (keep)
+            {
+                records.Slice(pos, size).CopyTo(destination[written..]);
+                written += size;
+
+                if (kind == TraceEventKind.PerTickSnapshot)
+                {
+                    TryLearnTickOffset(records.Slice(pos, size));
+                }
+            }
+
+            pos += size;
+        }
+
+        return written;
+    }
+
+    /// <summary>
+    /// Tick-boundary transition. Consumes any pending arm request, decides whether this tick is recorded, and advances
+    /// the derived tick counter. Called for every <c>TickStart</c>, which is always kept, so the counter cannot drift
+    /// from the builder's.
+    /// </summary>
+    private void OpenTick()
+    {
+        var pending = Interlocked.Exchange(ref _pendingArmTicks, NoPendingArm);
+        if (pending != NoPendingArm)
+        {
+            Volatile.Write(ref _remainingTicks, pending);
+        }
+
+        var remaining = Volatile.Read(ref _remainingTicks);
+        _armedForCurrentTick = remaining > 0;
+
+        if (_armedForCurrentTick)
+        {
+            Interlocked.Increment(ref _recordedTickCount);
+            if (remaining != AlwaysOnTicks)
+            {
+                Volatile.Write(ref _remainingTicks, remaining - 1);
+                // Notify on every armed tick so the UI badge counts down live, and so the final tick of a window
+                // clears it on exactly the tick it closes on.
+                PublishCaptureState();
+            }
+        }
+
+        _derivedTickCount++;
+    }
+
+    /// <summary>
+    /// Read the absolute tick number a <see cref="TraceEventKind.PerTickSnapshot"/> carries at wire offset 12 — the only
+    /// absolute tick number in the live stream — and reconcile it with the derived count.
+    /// </summary>
+    /// <remarks>
+    /// First snapshot establishes the offset. Every later snapshot re-checks it: a mismatch can only mean the derived
+    /// count skipped or gained a tick, i.e. a <c>TickStart</c> was dropped somewhere. That is the one silent-corruption
+    /// mode this filter could introduce, so it is surfaced as <see cref="_tickNumberingSuspect"/> and logged rather than
+    /// quietly re-based.
+    /// </remarks>
+    private void TryLearnTickOffset(ReadOnlySpan<byte> snapshotRecord)
+    {
+        if (snapshotRecord.Length < MinRecordSize + 4)
+        {
+            return;
+        }
+        var engineTick = BinaryPrimitives.ReadUInt32LittleEndian(snapshotRecord[MinRecordSize..]);
+        var offset = (long)engineTick - _derivedTickCount;
+
+        if (!Volatile.Read(ref _tickOffsetKnown))
+        {
+            // Offset first, flag second: a reader that observes the flag must never see a stale offset.
+            Volatile.Write(ref _tickNumberOffset, offset);
+            Volatile.Write(ref _tickOffsetKnown, true);
+            LogTickOffsetLearned(engineTick, _derivedTickCount, offset);
+            return;
+        }
+
+        if (offset != Volatile.Read(ref _tickNumberOffset) && !Volatile.Read(ref _tickNumberingSuspect))
+        {
+            Volatile.Write(ref _tickNumberingSuspect, true);
+            LogTickNumberingDrift(engineTick, _derivedTickCount, Volatile.Read(ref _tickNumberOffset), offset);
+        }
+    }
+
+    /// <summary>
+    /// Translate a builder-derived tick number into the engine's absolute one. Applied at the DTO boundary so the client
+    /// only ever sees one coordinate system.
+    /// </summary>
+    internal uint ToAbsoluteTick(uint derivedTick)
+    {
+        if (!Volatile.Read(ref _tickOffsetKnown))
+        {
+            return derivedTick;
+        }
+        var offset = Volatile.Read(ref _tickNumberOffset);
+        if (offset == 0)
+        {
+            return derivedTick;
+        }
+        var absolute = derivedTick + offset;
+        return absolute < 0 ? 0 : (uint)Math.Min(absolute, uint.MaxValue);
+    }
+
+    /// <summary>Minimum record size — the 12-byte common header present on every record.</summary>
+    private const int MinRecordSize = 12;
+
+    /// <summary>Path of the replay written by <see cref="AutoSaveOnTeardown"/>, or <c>null</c> if nothing was saved.</summary>
+    public string AutoSavedPath { get; private set; }
+
+    /// <summary>
+    /// Suppresses the teardown auto-save. Set when something else is already guaranteeing a durable artifact.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Auto-save exists because a live stream leaves nothing behind: the session's temp cache dies with it, and a
+    /// deliberately-recorded window would go with it.
+    /// </para>
+    /// <para>
+    /// <b>Nothing sets this today.</b> It briefly was set for sessions with a database, on the reasoning that the engine
+    /// writes a complete capture into that database's <c>profilings/</c> anyway, so a second file would only duplicate
+    /// it. That reasoning rested on a defect — a configured live port had been made to force the engine's default file
+    /// destination, which is precisely what on-demand capture exists to avoid. With a live-only run writing no file, the
+    /// recorded window is the ONLY artifact and suppressing its save discards the operator's armed ticks. The hook stays
+    /// for a caller that genuinely guarantees durability by other means; "there is probably a file somewhere" is not
+    /// that guarantee.
+    /// </para>
+    /// </remarks>
+    public bool SuppressAutoSave { get; set; }
+
+    /// <summary>
+    /// Where <see cref="AutoSaveOnTeardown"/> writes. Null means the machine-local captures directory.
+    /// </summary>
+    /// <remarks>
+    /// A session with a database sets this to that database's <c>profilings/</c>, which is where the Profiles list
+    /// looks — an endpoint-only Attach session has no database to co-locate with and keeps the default. This is the
+    /// whole difference between a capture the user can reopen and one they have to go find in local-app-data.
+    /// </remarks>
+    public string AutoSaveDirectory { get; set; }
+
+    /// <summary>Fires when a capture is auto-saved on teardown, carrying the resolved path.</summary>
+    public event Action<string> CaptureAutoSaved;
+
+    /// <summary>
+    /// Persist the session before it is torn down, so a deliberately-recorded window is never lost to an engine
+    /// restart or crash.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Only in cherry-pick mode, and only if a window was actually recorded.</b> In cherry-pick the retained data is
+    /// small, deliberate and precious — losing it is the bad outcome and an unwanted file is a trivial one. In
+    /// capture-everything mode the data is large and incidental, and silently writing multiple GB to the user's
+    /// local-app-data on every restart is not something a tool should do unasked; that flow prompts instead.
+    /// An attach where Record was never pressed leaves nothing behind at all.
+    /// </para>
+    /// <para>
+    /// <b>Ordering is mandatory.</b> <c>Dispose()</c> deletes the temp file and does not flush — the periodic timers do.
+    /// So the in-flight chunk and the open tick must be flushed here, before the save reads the manifest, or the most
+    /// recent ticks (usually the interesting ones) are missing from the saved replay.
+    /// </para>
+    /// <para>Best-effort: a failure to save must never take down the read loop or mask the reason the session ended.</para>
+    /// </remarks>
+    internal void AutoSaveOnTeardown(string reason)
+    {
+        if (_disposed || SuppressAutoSave || _captureMode != CaptureMode.CherryPick || !HasRecordedAnything || AutoSavedPath != null)
+        {
+            return;
+        }
+        if (_builder == null || _tempFile == null || _initialMetadataBytes == null)
+        {
+            return;
+        }
+
+        try
+        {
+            lock (_builderLock)
+            {
+                _builder.FlushCurrentChunk();
+                _builder.FlushTrailingTick();
+                _builder.FlushCurrentChunk();
+            }
+
+            var path = CaptureStorage.ResolveAutoSavePath(AutoSaveDirectory);
+            var bytes = SaveSessionAsync(path, CancellationToken.None).GetAwaiter().GetResult();
+            AutoSavedPath = path;
+            LogCaptureAutoSaved(path, bytes, Interlocked.Read(ref _recordedTickCount));
+            CaptureAutoSaved?.Invoke(path);
+
+            // Prune only after a successful write, so a budget that is already over cannot delete an older capture in
+            // exchange for one we then fail to produce. Retention follows the file: whichever directory it landed in is
+            // the one that just grew, and engine-written captures there are untouched because the two policies scan
+            // disjoint extensions.
+            CaptureStorage.ApplyRetention(path, LogCaptureAutoSaveFailed);
+        }
+        catch (Exception ex)
+        {
+            LogCaptureAutoSaveFailed($"{reason}: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}
+
+/// <summary>How an attach session treats incoming profiler records.</summary>
+public enum CaptureMode
+{
+    /// <summary>Record everything for as long as the session lives — the behaviour of every attach session before #805.</summary>
+    Everything = 0,
+
+    /// <summary>Record nothing until the operator arms a window; keep only the per-tick skeleton in between.</summary>
+    CherryPick = 1,
+}
+
+/// <summary>Coarse capture state, surfaced to the UI.</summary>
+public enum CaptureRunState
+{
+    /// <summary>Cherry-pick mode with no window open — only the exempt per-tick skeleton is retained.</summary>
+    Idle = 0,
+
+    /// <summary>A bounded window is open.</summary>
+    Recording = 1,
+
+    /// <summary>Capture-everything mode — unbounded.</summary>
+    Everything = 2,
+}

--- a/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.Logging.cs
+++ b/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.Logging.cs
@@ -50,4 +50,30 @@ public sealed partial class AttachSessionRuntime
     [LoggerMessage(Level = LogLevel.Error,
         Message = "Attach: reconnect rejected — Init signature changed; session marked unrecoverable")]
     private partial void LogInitMismatchUnrecoverable();
+
+    // ── On-demand tick capture (#805) ────────────────────────────────────────
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Capture: arm requested for {TickCount} tick(s) — takes effect at the next TickStart")]
+    private partial void LogCaptureArmRequested(int tickCount);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Capture: absolute tick numbering established — engine tick {EngineTick} maps to derived tick {DerivedTick} (offset {Offset})")]
+    private partial void LogTickOffsetLearned(uint engineTick, uint derivedTick, long offset);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Capture: tick numbering drifted — engine tick {EngineTick} vs derived {DerivedTick}; offset was {ExpectedOffset}, now {ActualOffset}. "
+                  + "A TickStart record was lost; reported tick numbers are no longer trustworthy.")]
+    private partial void LogTickNumberingDrift(uint engineTick, uint derivedTick, long expectedOffset, long actualOffset);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Capture: session saved to {Path} ({Bytes} bytes) before teardown — {RecordedTicks} tick(s) had been recorded")]
+    private partial void LogCaptureAutoSaved(string path, long bytes, long recordedTicks);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Capture: auto-save failed — {Reason}")]
+    private partial void LogCaptureAutoSaveFailed(string reason);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Attach: engine RESTART detected (session start {PreviousCreatedUtcTicks} → {NewCreatedUtcTicks}); ending this session rather than "
+                  + "continuing its tick axis into a new run")]
+    private partial void LogEngineRestartDetected(long previousCreatedUtcTicks, long newCreatedUtcTicks);
 }

--- a/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.cs
+++ b/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.cs
@@ -93,6 +93,18 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
     private IncrementalCacheBuilder _builder;
     private long _timestampFrequency;
     private byte[] _rawBlockBuffer = [];
+
+    /// <summary>
+    /// Destination for <see cref="FilterRecords"/> (#805). Grows to the largest block seen; never shrinks.
+    /// </summary>
+    /// <remarks>
+    /// Compacting in place inside <see cref="_rawBlockBuffer"/> would in fact be safe — the write cursor never overtakes
+    /// the read cursor, since a record is only copied after it has been walked. A separate buffer is used anyway so that
+    /// the raw block stays intact for the whole of <c>HandleBlock</c>: <see cref="ExtractThreadInfos"/> and any future
+    /// unfiltered inspection then read the engine's bytes, not a half-compacted version of them, with no ordering rule
+    /// to remember.
+    /// </remarks>
+    private byte[] _filteredBlockBuffer = [];
     private long _lastBlockReceivedTicks;
 
     /// <summary>
@@ -230,26 +242,37 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
     /// <summary>Fires when the engine sends a Shutdown frame — terminal.</summary>
     public event Action<string> ShutdownReceived;
 
-    private AttachSessionRuntime(Guid sessionId, string endpointAddress, string host, int port, ILogger logger)
+    private AttachSessionRuntime(Guid sessionId, string endpointAddress, string host, int port, ILogger logger, CaptureMode captureMode)
     {
         _sessionId = sessionId;
         _endpointAddress = endpointAddress;
         _host = host;
         _port = port;
         _logger = logger;
+        _captureMode = captureMode;
+        // The capture counter IS the mode: unbounded for Everything (pre-#805 behaviour, bit-for-bit), zero for
+        // CherryPick so nothing but the per-tick skeleton is retained until the operator arms a window. Records that
+        // arrive before the first TickStart follow the same rule, which is why this is set here and not at first tick.
+        _remainingTicks = captureMode == CaptureMode.CherryPick ? 0 : AlwaysOnTicks;
+        _armedForCurrentTick = captureMode != CaptureMode.CherryPick;
     }
 
     /// <summary>
     /// Starts a new attach-session runtime. Performs 3 × 2 s upfront TCP connect retry before returning.
     /// </summary>
     public static async Task<AttachSessionRuntime> StartAsync(string endpointAddress, ILogger logger, CancellationToken ct)
-        => await StartAsync(Guid.NewGuid(), endpointAddress, logger, ct).ConfigureAwait(false);
+        => await StartAsync(Guid.NewGuid(), endpointAddress, logger, ct, CaptureMode.Everything).ConfigureAwait(false);
 
     /// <summary>
     /// Overload that accepts an explicit session id — used by <c>SessionsController</c> so the temp file path matches the
     /// public <c>sessionId</c> from <see cref="SessionManager"/>.
     /// </summary>
-    public static async Task<AttachSessionRuntime> StartAsync(Guid sessionId, string endpointAddress, ILogger logger, CancellationToken ct)
+    /// <param name="captureMode">
+    /// <see cref="CaptureMode.Everything"/> preserves the pre-#805 behaviour and is the default for every existing
+    /// caller. <see cref="CaptureMode.CherryPick"/> starts the session idle — see <c>12-on-demand-tick-capture.md</c>.
+    /// </param>
+    public static async Task<AttachSessionRuntime> StartAsync(Guid sessionId, string endpointAddress, ILogger logger, CancellationToken ct,
+        CaptureMode captureMode = CaptureMode.Everything)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpointAddress);
         var (host, port) = ParseEndpoint(endpointAddress);
@@ -293,7 +316,7 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
                 lastError);
         }
 
-        var runtime = new AttachSessionRuntime(sessionId, endpointAddress, host, port, logger);
+        var runtime = new AttachSessionRuntime(sessionId, endpointAddress, host, port, logger, captureMode);
         runtime.LogStarting(host, port);
         runtime.SetConnectionStatus("connected");
         runtime.LogConnected(host, port);
@@ -379,7 +402,16 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
                 throw new ArgumentOutOfRangeException(nameof(chunkIdx),
                     $"Chunk index {chunkIdx} out of range (manifest has {_builder.ChunkManifest.Count} entries).");
             }
-            return ValueTask.FromResult(_builder.ChunkManifest[chunkIdx]);
+            var entry = _builder.ChunkManifest[chunkIdx];
+            // #805: report the chunk's tick range in absolute simulation ticks, matching the manifest and tick summaries
+            // the client already holds. Byte offset and length are deliberately untouched — they address the temp file.
+            // Applying the translation here rather than in the controller keeps ProfilerController generic across
+            // Trace and Attach sessions.
+            return ValueTask.FromResult(entry with
+            {
+                FromTick = ToAbsoluteTick(entry.FromTick),
+                ToTick = ToAbsoluteTick(entry.ToTick),
+            });
         }
     }
 
@@ -691,6 +723,9 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
 
                     case LiveFrameType.Shutdown:
                         LogShutdownReceived();
+                        // #805: the engine quit cleanly and this session is terminal, so a recorded window would die
+                        // with the temp file. Save before anyone can dispose us.
+                        AutoSaveOnTeardown("engine_shutdown");
                         ShutdownReceived?.Invoke("engine_shutdown");
                         BroadcastDelta(new LiveStreamEventDto(Kind: "shutdown", Status: "engine_shutdown"));
                         return StreamEndReason.Shutdown;
@@ -803,7 +838,26 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
             BroadcastDelta(new LiveStreamEventDto(Kind: "shutdown", Status: "init_mismatch"));
             return false;
         }
-        // Same signature → continue feeding from where we left off. The builder's internal tick counter survives the
+        // #805: signature matching is not enough to tell "the socket blipped" from "the app was restarted". The Init
+        // signature deliberately excludes CreatedUtcTicks, so the SAME binary relaunched hashes identically — and
+        // continuing to feed the old builder would silently report run 2's tick 1 as tick N+1, because the builder's
+        // tick counter derives from counting TickStart markers and never resets.
+        //
+        // CreatedUtcTicks is the engine's session start time, so it separates the two cases exactly:
+        //   same value  → one engine process, transient TCP drop → resume, as before.
+        //   different   → a new process → the tick axis restarted → end this session.
+        // Ending it is a correctness fix, not a new limitation: true tick numbers and two runs on one timeline cannot
+        // both hold without a (run, tick) composite, which would mean changing TickSummary in Typhon.Profiler.
+        if (headerDto.CreatedUtcTicks != _initialHeader.CreatedUtcTicks)
+        {
+            LogEngineRestartDetected(_initialHeader.CreatedUtcTicks, headerDto.CreatedUtcTicks);
+            AutoSaveOnTeardown("engine_restarted");
+            ShutdownReceived?.Invoke("engine_restarted");
+            BroadcastDelta(new LiveStreamEventDto(Kind: "shutdown", Status: "engine_restarted"));
+            return false;
+        }
+
+        // Same process → continue feeding from where we left off. The builder's internal tick counter survives the
         // reconnect, so subsequent TickStart records resume the same tickNumber sequence.
         LogInitReceived(reader.Systems.Count, reader.Header.WorkerCount, reader.Header.BaseTickRate);
         return true;
@@ -916,13 +970,32 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
         // Walk for ThreadInfo records BEFORE feeding the builder. The builder treats records as opaque bytes; we
         // need the slot→name mapping surfaced to the client via SSE delta + metadata snapshot regardless of which
         // chunk a record happens to land in (otherwise late-arriving worker ThreadInfo records get buried in
-        // unloaded chunks).
+        // unloaded chunks). Runs on the UNFILTERED buffer — ThreadInfo is exempt anyway, but reading it here keeps
+        // slot naming independent of capture state by construction rather than by coincidence.
         ExtractThreadInfos(_rawBlockBuffer.AsSpan(0, uncompressedBytes));
 
-        lock (_builderLock)
+        // #805 on-demand tick capture: drop detail records for ticks outside an armed window. Filtering is per record,
+        // never per block — a Block frame is a timestamp-ordered merge across all thread slots drained on a 1 ms
+        // cadence, so one block can straddle a tick boundary.
+        if (_filteredBlockBuffer.Length < uncompressedBytes)
         {
-            _builder.FeedRawRecords(_rawBlockBuffer.AsSpan(0, uncompressedBytes));
+            _filteredBlockBuffer = new byte[uncompressedBytes];
         }
+        var retainedBytes = FilterRecords(_rawBlockBuffer.AsSpan(0, uncompressedBytes), _filteredBlockBuffer);
+
+        if (retainedBytes > 0)
+        {
+            lock (_builderLock)
+            {
+                _builder.FeedRawRecords(_filteredBlockBuffer.AsSpan(0, retainedBytes));
+            }
+        }
+
+        // Published LAST, and as a pair. An observer that sees the received count advance has therefore also seen this
+        // block's arm-state transitions and its records reach the builder — so the two counters are never mutually
+        // inconsistent, and "bytes received" never advertises work that has not happened yet.
+        Interlocked.Add(ref _recordBytesRetained, retainedBytes);
+        Interlocked.Add(ref _recordBytesReceived, uncompressedBytes);
     }
 
     /// <summary>
@@ -1001,7 +1074,11 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
         // Builder fires synchronously inside FeedRawRecords (which we already hold _builderLock for). Project to DTO and
         // append; SSE delta fanout happens outside the lock to avoid back-pressure on the read loop.
         var dto = new TickSummaryDto(
-            TickNumber: summary.TickNumber,
+            // #805: translated from the builder's attach-relative count to the engine's true simulation tick. Applied at
+            // every server→client boundary (here, the chunk manifest, and IChunkProvider) so the client only ever sees
+            // one coordinate system — the client correlates summaries against manifest tick ranges, so a boundary that
+            // translated only one of them would silently mis-map chunks to ticks.
+            TickNumber: ToAbsoluteTick(summary.TickNumber),
             StartUs: summary.StartUs,
             DurationUs: summary.DurationUs,
             EventCount: summary.EventCount,
@@ -1023,8 +1100,8 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
     {
         var isContinuation = (entry.Flags & TraceFileCacheConstants.FlagIsContinuation) != 0;
         var dto = new ChunkManifestEntryDto(
-            FromTick: entry.FromTick,
-            ToTick: entry.ToTick,
+            FromTick: ToAbsoluteTick(entry.FromTick),
+            ToTick: ToAbsoluteTick(entry.ToTick),
             EventCount: entry.EventCount,
             IsContinuation: isContinuation);
         _chunkManifest.Add(dto);
@@ -1330,6 +1407,17 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
     public void Dispose()
     {
         if (_disposed) return;
+
+        // Last chance to preserve a recorded window, and it must run BEFORE _disposed is set — AutoSaveOnTeardown
+        // refuses to run on a disposed runtime, and the temp file holding the capture is deleted a few lines below.
+        //
+        // The teardown frames (engine shutdown, engine restart) are not the only way a session ends: the operator can
+        // close it, or press Stop watching, and both routes arrive here having recorded exactly the ticks they meant
+        // to. While a live run also wrote a complete engine capture this merely duplicated it; now that a live-only
+        // run writes nothing else, skipping it here would silently discard the only artifact of the recording.
+        // Idempotent — a window already saved by a shutdown frame is not written twice.
+        try { AutoSaveOnTeardown("session_closed"); } catch { }
+
         _disposed = true;
         try { _flushChunkTimer?.Dispose(); } catch { }
         try { _trailingTickTimer?.Dispose(); } catch { }

--- a/tools/Typhon.Workbench/Sessions/CaptureStorage.cs
+++ b/tools/Typhon.Workbench/Sessions/CaptureStorage.cs
@@ -1,0 +1,173 @@
+using System.Globalization;
+using Typhon.Engine;
+
+namespace Typhon.Workbench.Sessions;
+
+/// <summary>
+/// Where the Workbench writes attach-session captures, and how it keeps that directory from growing without bound (#805).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why not <c>profilings/</c>.</b> #613 gave databases a managed <c>profilings/</c> directory with a
+/// <see cref="RetentionPolicy"/>, but that path is reachable only from an <c>OpenSession</c>: it is resolved from the
+/// database's own file path, and an attach session's "file path" is a <c>host:port</c> endpoint. The engine does not
+/// put its database path on the live wire, so an attach capture has no database to file itself under and lands in the
+/// user's local-app-data instead.
+/// </para>
+/// <para>
+/// <b>Why not <c>TraceRetention.Prune</c>.</b> It enumerates <c>*.typhon-trace</c> plus their sidecars inside a
+/// <c>profilings/</c> directory. Attach captures are self-contained <c>.typhon-replay</c> files with no sidecar, so
+/// pointing that pruner here would scan a directory it does not understand and silently delete nothing. What IS reused
+/// is <see cref="RetentionPolicy"/> itself — same record, same <c>retention.json</c> file name, same
+/// budget/keep-latest/pin semantics — so a user who has learned one directory's policy has learned both.
+/// </para>
+/// <para>
+/// <b>The writer prunes.</b> That is the policy's own stated contract: <i>"whoever writes a capture prunes first, from
+/// this file, with no tooling required"</i>. This class is that writer for attach captures.
+/// </para>
+/// </remarks>
+public static class CaptureStorage
+{
+    /// <summary>Extension of a self-contained attach capture.</summary>
+    public const string ReplayExtension = ".typhon-replay";
+
+    /// <summary>
+    /// Environment override for <see cref="CapturesDirectory"/>. Exists so tests never touch — and
+    /// <see cref="ApplyRetention"/> never <i>deletes from</i> — the developer's real capture archive.
+    /// </summary>
+    public const string DirectoryOverrideVariable = "TYPHON_WORKBENCH_CAPTURES_DIR";
+
+    /// <summary>Directory holding attach captures: <c>%LOCALAPPDATA%/Typhon/Workbench/captures</c> (XDG equivalent on POSIX).</summary>
+    public static string CapturesDirectory
+    {
+        get
+        {
+            var overrideDir = Environment.GetEnvironmentVariable(DirectoryOverrideVariable);
+            if (!string.IsNullOrWhiteSpace(overrideDir))
+            {
+                return overrideDir;
+            }
+
+            string root;
+            if (OperatingSystem.IsWindows())
+            {
+                root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            }
+            else
+            {
+                var xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+                root = !string.IsNullOrWhiteSpace(xdg)
+                    ? xdg
+                    : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+            }
+            return Path.Combine(root, "Typhon", "Workbench", "captures");
+        }
+    }
+
+    /// <summary>Resolve a fresh timestamped capture path, creating the directory if needed.</summary>
+    public static string ResolveDefaultCapturePath()
+    {
+        var dir = CapturesDirectory;
+        Directory.CreateDirectory(dir);
+        var stamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
+        return Path.Combine(dir, $"typhon-capture-{stamp}{ReplayExtension}");
+    }
+
+    /// <summary>Path for a capture written automatically when a session is torn down, distinguishable from a manual save.</summary>
+    /// <param name="directory">
+    /// Where to write. Null selects the machine-local captures directory — the fallback for an endpoint-only Attach
+    /// session, which has no database to co-locate the capture with. A session that HAS a database passes that
+    /// database's <c>profilings/</c>, so the recorded window lands where the Profiles list already looks.
+    /// </param>
+    public static string ResolveAutoSavePath(string directory = null)
+    {
+        var dir = string.IsNullOrWhiteSpace(directory) ? CapturesDirectory : directory;
+        Directory.CreateDirectory(dir);
+        var stamp = DateTime.UtcNow.ToString("yyyyMMddTHHmmssfffZ", CultureInfo.InvariantCulture);
+        return Path.Combine(dir, $"typhon-autosave-{stamp}{ReplayExtension}");
+    }
+
+    /// <summary>
+    /// Enforce the captures directory's <see cref="RetentionPolicy"/>, newest-first: keep
+    /// <see cref="RetentionPolicy.KeepLatest"/> captures unconditionally, then delete oldest-first until the total is
+    /// within <see cref="RetentionPolicy.BudgetBytes"/>. Pinned names are never deleted but still count toward the
+    /// budget, matching the policy's documented semantics.
+    /// </summary>
+    /// <param name="justWritten">
+    /// The capture that was just produced. Never deleted by this pass — evicting the file whose creation triggered the
+    /// prune would make capturing unreliable rather than bounded.
+    /// </param>
+    /// <param name="onFailure">Invoked with a reason if pruning fails. Retention is best-effort; it must never fail a save.</param>
+    public static void ApplyRetention(string justWritten, Action<string> onFailure)
+    {
+        try
+        {
+            // Prune WHERE THE FILE LANDED, not where captures live by default. Since a session with a database saves
+            // into that database's profilings/ instead, reading the default here would prune an unrelated directory
+            // while leaving the one that just grew unbounded — and `justWritten` would match nothing in it, quietly
+            // disabling the "never evict what we just wrote" guard.
+            //
+            // Pointing this at profilings/ is safe for engine-written captures: the scan below is restricted to
+            // *.typhon-replay, and engine retention enumerates *.typhon-trace. The two sets are disjoint, so each
+            // directory keeps exactly one owner per file kind rather than two policies racing over the same files.
+            var dir = Path.GetDirectoryName(Path.GetFullPath(justWritten));
+            if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+            {
+                return;
+            }
+
+            var policy = RetentionPolicy.Read(dir, out _);
+            var files = new List<FileInfo>();
+            foreach (var path in Directory.EnumerateFiles(dir, "*" + ReplayExtension))
+            {
+                files.Add(new FileInfo(path));
+            }
+            // Newest first: index < KeepLatest is protected by the floor.
+            files.Sort((a, b) => b.LastWriteTimeUtc.CompareTo(a.LastWriteTimeUtc));
+
+            long total = 0;
+            foreach (var f in files)
+            {
+                total += f.Length;
+            }
+
+            var keepLatest = Math.Max(policy.KeepLatest, 1);
+            var budget = policy.BudgetBytes;
+            if (budget <= 0)
+            {
+                return; // Non-positive budget disables eviction, per the policy's own contract.
+            }
+
+            for (var i = files.Count - 1; i >= keepLatest && total > budget; i--)
+            {
+                var candidate = files[i];
+                if (policy.IsPinned(candidate.Name))
+                {
+                    continue;
+                }
+                if (string.Equals(candidate.FullName, Path.GetFullPath(justWritten), StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                var size = candidate.Length;
+                try
+                {
+                    candidate.Delete();
+                    total -= size;
+                }
+                catch (IOException)
+                {
+                    // Someone has it open — skip rather than fail the save that triggered this.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Same.
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            onFailure?.Invoke($"retention pass failed: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/tools/Typhon.Workbench/Sessions/DatabaseHolder.cs
+++ b/tools/Typhon.Workbench/Sessions/DatabaseHolder.cs
@@ -11,8 +11,24 @@ namespace Typhon.Workbench.Sessions;
 /// <param name="Pid">Process id of the holder, as recorded in its lock file.</param>
 /// <param name="MachineName">Machine the holder runs on. A different machine cannot be probed for liveness, so such a lock is always treated as live.</param>
 /// <param name="StartedAt">When the holder acquired the database.</param>
-public sealed record DatabaseHolder(int Pid, string MachineName, DateTimeOffset StartedAt)
+/// <param name="ProfilerEndpoint">
+/// <c>host:port</c> of the holder's live profiler, or <c>null</c> when it advertises none. This is the one field read
+/// from <c>db.lock</c> rather than taken from the refusal, and deliberately so: it is not <i>identity</i>. The reason
+/// identity must come from the exception — that a re-read could name a process which never blocked us — does not apply
+/// to an address, where the cost of being stale is a refused connect that the caller already has to handle.
+/// </param>
+public sealed record DatabaseHolder(int Pid, string MachineName, DateTimeOffset StartedAt, string ProfilerEndpoint = null)
 {
+    /// <summary>True when the holder advertises a live profiler this session could watch.</summary>
+    public bool IsWatchable => !string.IsNullOrWhiteSpace(ProfilerEndpoint);
+
+    /// <summary>
+    /// Reads the holder's advertised profiler endpoint from <c>db.lock</c>, or <c>null</c> if it advertises none or the
+    /// lock cannot be read. Best-effort: an unreadable lock means "cannot watch", never an error.
+    /// </summary>
+    public static string ReadProfilerEndpoint(string bundleOrDatabasePath) =>
+        Typhon.Engine.DatabaseLockFile.TryReadLock(bundleOrDatabasePath, out var info) ? info.ProfilerEndpoint : null;
+
     /// <summary>
     /// A one-line description for the paused banner — "PID 12345 on DESKTOP-ABC (since 2026-08-03 14:02:11Z)". Naming the holder is the difference between a
     /// user closing the right process and guessing.

--- a/tools/Typhon.Workbench/Sessions/ILiveProfilerHost.cs
+++ b/tools/Typhon.Workbench/Sessions/ILiveProfilerHost.cs
@@ -1,0 +1,25 @@
+namespace Typhon.Workbench.Sessions;
+
+/// <summary>
+/// A session that is watching a running engine over TCP.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Endpoint handlers used to ask <c>session is AttachSession</c> to find the live runtime. That worked while "watching a
+/// live engine" and "being an attach session" were the same thing. They stopped being the same thing once an
+/// <see cref="OpenSession"/> — a database whose own application currently holds it, so the session opened paused — could
+/// watch that application. The session is still an Open session, and its kind never changes; what changes is whether it
+/// is watching. This is the same reasoning that produced <see cref="SessionCapability"/>: a capability is acquired and
+/// released during a session's life, and no kind enum can express that.
+/// </para>
+/// <para>
+/// <b>Not every <c>is AttachSession</c> test should become this one.</b> Some genuinely ask about kind — projecting the
+/// session DTO, or enforcing the one-session-per-endpoint rule. Those must stay as they are. This interface is for the
+/// handlers that only ever wanted "give me the live stream".
+/// </para>
+/// </remarks>
+public interface ILiveProfilerHost
+{
+    /// <summary>The live runtime, or <c>null</c> when this session is not currently watching anything.</summary>
+    AttachSessionRuntime LiveRuntime { get; }
+}

--- a/tools/Typhon.Workbench/Sessions/OpenSession.cs
+++ b/tools/Typhon.Workbench/Sessions/OpenSession.cs
@@ -3,10 +3,63 @@ using Typhon.Workbench.Schema;
 
 namespace Typhon.Workbench.Sessions;
 
-public sealed class OpenSession : ISession, IDisposable
+public sealed class OpenSession : ISession, ILiveProfilerHost, IDisposable
 {
     public Guid Id { get; }
     public string FilePath { get; }
+
+    // ── Watching the application that holds this database ────────────────────────────────────────────────────────
+    //
+    // The pairing this exists for: your application is running and holds the database, so this session opened PAUSED.
+    // From there it can watch the application's live profiler over TCP, and when the application exits the coordinator
+    // promotes the session to a real open — at which point the database AND the capture the engine wrote into its own
+    // profilings/ are both available, already correlated, with no import step.
+    //
+    // Blocker B1 (a live engine holds its database exclusively) is what makes this a sequence rather than a
+    // simultaneity: you cannot read the data while the application runs. You were never trying to. You were trying to
+    // be positioned while it ran, and to read afterwards.
+
+    private AttachSessionRuntime _liveRuntime;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <see cref="Volatile"/> for the same reason <see cref="Engine"/> is: written when watching starts or stops,
+    /// read from request threads.
+    /// </remarks>
+    public AttachSessionRuntime LiveRuntime => Volatile.Read(ref _liveRuntime);
+
+    /// <summary>True while this session is streaming from the application that holds its database.</summary>
+    public bool IsWatchingLive => Volatile.Read(ref _liveRuntime) != null;
+
+    /// <summary>
+    /// Begin watching a live engine. Replaces any previous runtime, so a re-watch after a dropped connection is a
+    /// plain call rather than a state machine the caller has to drive.
+    /// </summary>
+    public void StartWatching(AttachSessionRuntime runtime)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        // The recorded window is saved WITH the database, in its own profilings/ directory.
+        //
+        // This used to set SuppressAutoSave, on the reasoning that the engine writes a complete capture there anyway so
+        // a second file would only duplicate it. That reasoning was built on a defect: enabling a live port had been
+        // made to force a default file destination, so the "complete capture" being cited as already-durable was an
+        // artifact the feature was never supposed to produce. With the engine writing nothing for a live-only run, the
+        // window recorded here is the ONLY artifact — suppressing its save would silently discard the very ticks the
+        // operator armed. Co-locating it with the database is also what makes it reachable: the Profiles list reads
+        // that directory.
+        runtime.SuppressAutoSave = false;
+        runtime.AutoSaveDirectory = TraceLocation.ProfilingsDirectoryOf(FilePath);
+        var previous = Interlocked.Exchange(ref _liveRuntime, runtime);
+        previous?.Dispose();
+    }
+
+    /// <summary>Stop watching and dispose the runtime. Idempotent — returns false when nothing was being watched.</summary>
+    public bool StopWatching()
+    {
+        var previous = Interlocked.Exchange(ref _liveRuntime, null);
+        previous?.Dispose();
+        return previous != null;
+    }
 
     // ── Pause / resume (#621) ────────────────────────────────────────────────────────────────────────────────────
     //
@@ -85,7 +138,10 @@ public sealed class OpenSession : ISession, IDisposable
         get
         {
             var hasDatabase = Volatile.Read(ref _engine) != null;
-            var hasProfiler = !_profileHost.IsEmpty;
+            // Watching a live engine profiles just as much as holding an attached capture does — both serve
+            // /profiler/*. Panels ask for the capability, never the kind, which is what lets a paused Open session
+            // light up the profiler UI without pretending to be an Attach session.
+            var hasProfiler = !_profileHost.IsEmpty || Volatile.Read(ref _liveRuntime) != null;
             return hasDatabase
                 ? (hasProfiler ? DatabaseAndProfiler : DatabaseOnly)
                 : (hasProfiler ? ProfilerOnly : Nothing);
@@ -234,7 +290,10 @@ public sealed class OpenSession : ISession, IDisposable
 
     public void Dispose()
     {
-        // Profiles first: they hold file handles on captures inside the bundle the engine is about to release.
+        // The live runtime first: it owns a socket and a temp file, and its auto-save must run while the builder is
+        // still alive. Dispose deletes that temp file, so anything that wants the capture has to happen before it.
+        StopWatching();
+        // Profiles next: they hold file handles on captures inside the bundle the engine is about to release.
         _profileHost.DetachAll();
         // Null while paused — a paused session owns no engine, and disposing one is the whole of what pausing did.
         Volatile.Read(ref _engine)?.Dispose();

--- a/tools/Typhon.Workbench/Streams/ProfilerLiveStream.cs
+++ b/tools/Typhon.Workbench/Streams/ProfilerLiveStream.cs
@@ -36,7 +36,10 @@ public static class ProfilerLiveStream
             session = s2;
         }
 
-        if (session is not AttachSession attach)
+        // Any session that is watching a live engine streams — an Attach session always, a database session while its
+        // application holds it. Kind is the wrong question here; #617 moved panel visibility onto capability for exactly
+        // this reason and the live stream is the same shape of decision.
+        if (session is not ILiveProfilerHost { LiveRuntime: { } liveRuntime })
         {
             ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
             return;
@@ -44,7 +47,7 @@ public static class ProfilerLiveStream
 
         await SseExtensions.WriteSseHeadersAsync(ctx, ct);
 
-        var runtime = attach.Runtime;
+        var runtime = liveRuntime;
         var (subscriberId, reader) = runtime.Subscribe();
 
         try
@@ -60,6 +63,9 @@ public static class ProfilerLiveStream
             {
                 await WriteEventAsync(ctx, new LiveStreamEventDto(Kind: "threadInfoAdded", ThreadInfo: info), ct);
             }
+            // #805: seed the capture state on connect. Without this a client that subscribes between two transitions
+            // would render "not recording" through an entire in-flight window, since deltas only fire on change.
+            await WriteEventAsync(ctx, new LiveStreamEventDto(Kind: "captureStateChanged", CaptureState: runtime.CaptureState), ct);
             await WriteEventAsync(ctx, new LiveStreamEventDto(Kind: "heartbeat", Status: runtime.ConnectionStatus), ct);
 
             await DrainLoopAsync(ctx, reader, runtime, ct);


### PR DESCRIPTION
Record the ticks you want and store nothing else, and reach a live engine from the database it holds rather than through a separate entry mode.

Design docs (`typhon-claude`, same branch): [`design/Profiler/12-on-demand-tick-capture.md`](https://github.com/Log2n-io/Typhon-Claude/blob/feature/wb-snap/design/Profiler/12-on-demand-tick-capture.md) · [`design/Apps/Workbench/12-live-attach-as-a-database-capability.md`](https://github.com/Log2n-io/Typhon-Claude/blob/feature/wb-snap/design/Apps/Workbench/12-live-attach-as-a-database-capability.md)

## What it does

**Cherry-picked capture.** The operator arms a number of ticks; the engine keeps emitting everything over the wire and the attach runtime drops what was not armed, retaining a per-tick skeleton (`TickStart`/`TickEnd`, metronome wait, overload counters, gauge snapshot) so tick numbering stays absolute across the windows that were skipped. Measured on a 2,000-entity shard: **1.04 MB retained against 25.84 MB received.**

**Live attach as a database capability.** A database held by another process opens paused. If that process advertises a profiler port in its `db.lock`, the paused banner offers *Watch live* — the session stays `kind === 'open'`, so it keeps the Profiles list, the correlation bridges and every database view. The endpoint-only Attach tab stays for the case with no database.

**The recorded window is durable and reachable.** It is saved on every teardown route — engine shutdown, engine restart, stopping the watch, closing the session — into the database's own `profilings/` when the session has one. `ProfileCatalog` reads a replay's header out of its embedded source metadata, so it lists and attaches exactly like an engine-written capture.

**The timeline tells the truth about time.** Only recorded ticks are drawn, with a hatched band inserted wherever the tick axis jumps. The band takes real space rather than overpainting its neighbours, so bars, GC markers, the selection overlay, labels and hit-testing all read one shared offset table.

**`typhon telemetry live`.** The live port and its wait are settable by the tool that writes the file, with an F4 row in the editor; `telemetry effective` reports both output channels and says when neither is set.

## Two things this PR undoes from its own history

Recorded in the design docs rather than quietly dropped, because the way they were wrong is the useful part.

**A live port must not force a file.** A change earlier in this branch made a configured live port fill in the engine's default capture destination. `Live` and `Trace` are independent output channels, and the result defeated the feature above it: the operator armed 100 ticks and the engine wrote a complete capture of the whole run beside the database anyway. Reverted — an explicit trace path still wins, so wanting both is one setting away, and the cost of live-only (no CPU sampling, which is file-mode only) is now a consequence of a choice the user made.

**The capture-routing phase was not superseded.** Its supersession argued the recorded window was a subset of a file that was already durable — a file that existed only because of the change above. A justification resting on the side effect of the thing it justifies is circular, and it survived because both halves had the same author.

## Verification

| | |
|---|---|
| Workbench (.NET) | **714 passed**, 0 failed |
| Engine, profiler + storage + telemetry | **489 passed** |
| Shell | **41 passed** |
| Client (vitest) | **1999 passed** / 207 files |
| `tsc --noEmit` | clean |
| Policy gate incl. doc links | pass |

The full engine suite reports 4 failures **when built to a relocated output directory** (a workaround for a locked analyzer DLL): one test walks up from the binary directory to find `src/Typhon.Engine/Storage`, and three registry tests require the database not to be under `%TEMP%`. Its own check was run by hand over the `Storage` diff — no forbidden `Wal|Lsn|Fpi` identifiers. **Please re-run the engine suite in place.**

## Notes for review

- `useTraceBackedSession` lost its session-kind clause: a watching session has the profiler capability and no file, and was being offered Call Tree scoping, which needs one.
- `CaptureStorage.ApplyRetention` now prunes the directory the capture landed in rather than the machine-local default; it scans `*.typhon-replay` only, so engine-written `*.typhon-trace` files are never candidates — asserted by a test with a 1-byte budget.
- `POST /save-replay` still requires an Attach session, so *Capture & Analyse* is not offered on a watching database session. Unreachable from the UI today, and auto-save covers that path.
