### PR TITLE
#817 DrainPendingClusterFinalizations never disposed its accessors, so the checkpoint gate never opened

### DIFF
--- a/rules/durability.md
+++ b/rules/durability.md
@@ -862,6 +862,21 @@ The 8-step checkpoint pipeline. Step ordering is load-bearing.
     while caller still holds OLC write lock on evicted slot's node;
     same corruption as CP-11
 
+### CP-13: ActiveChunkWriters conservation `[fatal][silent]`
+  invariant every IncrementActiveChunkWriters is matched by exactly one DecrementActiveChunkWriters
+  invariant no writer in flight → ∀ page: page.ACW == 0
+  note CP-11 and CP-12 constrain when ACW may be observed non-zero and when the decrement may be
+       deferred; NEITHER requires that it ever happens. Every ChunkAccessor that dirties a slot must
+       therefore reach CommitChanges() or Dispose() — an accessor abandoned without either leaks the
+       registration permanently, because the release is driven only by those two paths.
+  scope: ChunkAccessor.MarkSlotDirty, ChunkAccessor.CommitChanges, ChunkAccessor.Dispose,
+         ChangeSet.FlushDeferredEvictions, ArchetypeClusterState.DrainPendingClusterFinalizations
+  on_violation: the leaked page is skipped by CP-11 in EVERY checkpoint cycle, so CK-03's coverage gate
+    never opens, CheckpointLSN never advances and CK-04 recycles no WAL segment. The log then grows at
+    the full write rate until the writer stalls and the engine raises WalBackPressureTimeout — observed
+    as 22 GB across 86 segments in four minutes against a 120 MB data file (#817). Silent: nothing is
+    corrupted and nothing is slow; a counter simply never returns to zero.
+
 ---
 
 ## Module: Seqlock

--- a/src/Typhon.Engine/Ecs/internals/ArchetypeClusterState.cs
+++ b/src/Typhon.Engine/Ecs/internals/ArchetypeClusterState.cs
@@ -388,8 +388,14 @@ internal sealed unsafe class ArchetypeClusterState
 
         var ids = _drainedClusterIds;
         bool hasCluster = ClusterSegment != null;
-        var clusterAccessor = hasCluster ? ClusterSegment.CreateChunkAccessor() : default;
-        var transientAccessor = TransientSegment != null ? TransientSegment.CreateChunkAccessor() : default;
+        // `using`, because GetChunkAddress(chunkId, dirty: true) below registers an ActiveChunkWriter on each
+        // chunk's page and only Dispose -> CommitChanges releases it (CP-13). Without it every drained cluster left
+        // one ACW on its page forever, so CP-11 skipped that page in EVERY checkpoint cycle: CK-03's coverage gate
+        // never opened, CheckpointLSN never advanced, no WAL segment was ever recycled, and the log grew at the
+        // full write rate until the writer stalled and the process died with WalBackPressureTimeout (#817).
+        // Disposing a `default` accessor is safe — Dispose returns immediately when _segment is null.
+        using var clusterAccessor = hasCluster ? ClusterSegment.CreateChunkAccessor() : default;
+        using var transientAccessor = TransientSegment != null ? TransientSegment.CreateChunkAccessor() : default;
 
         for (int i = 0; i < count; i++)
         {

--- a/src/Typhon.Engine/Storage/internals/PagedMMF.cs
+++ b/src/Typhon.Engine/Storage/internals/PagedMMF.cs
@@ -1862,6 +1862,50 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
     /// </summary>
     protected virtual bool IsProtectedPage(int filePageIndex) => false;
 
+    // ─── Page-counter census (CP-13 / #817) ──────────────────────────────────────────────────────────────────────
+    // Read with the workload QUIESCENT. That is the whole point: while anything is in flight, a counter that is too
+    // high is indistinguishable from one that is legitimately busy, which is why an ACW leak survived 5 000+ tests
+    // and only surfaced as a WalBackPressureTimeout ten minutes into a demo run.
+
+    /// <summary>Live <see cref="PageInfo.ActiveChunkWriters"/> for a page. Non-zero at quiesce proves a leaked registration.</summary>
+    internal int ActiveChunkWritersOf(int memPageIndex) => Volatile.Read(ref _memPagesInfo[memPageIndex].ActiveChunkWriters);
+
+    /// <summary>Pages holding a writer registration. Must be zero at quiesce (CP-13).</summary>
+    internal int CountPagesWithActiveChunkWriters()
+    {
+        var n = 0;
+        for (var i = 0; i < _memPagesInfo.Length; i++)
+        {
+            if (Volatile.Read(ref _memPagesInfo[i].ActiveChunkWriters) != 0)
+            {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    /// <summary>Live <see cref="PageInfo.DirtyCounter"/> for a page.</summary>
+    internal int DirtyCounterOf(int memPageIndex) => Volatile.Read(ref _memPagesInfo[memPageIndex].DirtyCounter);
+
+    /// <summary>Pages still dirty, the cache size, and the lowest dirty page index (-1 if none).</summary>
+    internal (int Dirty, int Total, int FirstDirtyPage) CountDirtyPages()
+    {
+        var n = 0;
+        var first = -1;
+        for (var i = 0; i < _memPagesInfo.Length; i++)
+        {
+            if (Volatile.Read(ref _memPagesInfo[i].DirtyCounter) > 0)
+            {
+                n++;
+                if (first < 0)
+                {
+                    first = i;
+                }
+            }
+        }
+        return (n, _memPagesInfo.Length, first);
+    }
+
     internal void IncrementDirty(int memPageIndex)
     {
         var pi = _memPagesInfo[memPageIndex];

--- a/test/Typhon.Engine.Tests/Data/ECS/ClusterMigrationTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/ClusterMigrationTests.cs
@@ -1452,4 +1452,73 @@ class ClusterMigrationTests : TestBase<ClusterMigrationTests>
         Assert.That((cs.ClusterProcessBitmap[chunkC >> 6] >> (chunkC & 63)) & 1L, Is.EqualTo(0L),
             "interior move with no extreme change avoids the fence-time process loop entirely");
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // CP-13 — ActiveChunkWriters conservation across cluster finalisation
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// CP-13: every ActiveChunkWriters registration is released. Emptying a cluster queues it for
+    /// <c>DrainPendingClusterFinalizations</c>, which opens ChunkAccessors and dirties each drained chunk's page.
+    /// Those accessors must reach Dispose/CommitChanges or the registration leaks permanently.
+    /// </summary>
+    /// <remarks>
+    /// The regression this pins is #817, and it is worth spelling out why 5 000 tests walked past it. A leaked ACW
+    /// corrupts nothing, throws nothing and costs no measurable time — its only consequence is that CP-11 skips
+    /// that page in EVERY subsequent checkpoint cycle, so CK-03's coverage gate never opens, no WAL segment is ever
+    /// recycled, and the log grows at the full write rate until the writer stalls. In the demo that surfaced ten
+    /// minutes later as a WalBackPressureTimeout thrown from the tick fence — pointing at the WAL writer, which was
+    /// innocent. Nothing observable connects the two ends, which is exactly why the invariant has to be asserted
+    /// directly rather than inferred from behaviour.
+    /// <para>
+    /// The assertion must run QUIESCENT — no open transaction, no accessor alive. While anything is in flight a
+    /// non-zero count is legitimate, and indistinguishable from a leak.
+    /// </para>
+    /// </remarks>
+    [Test]
+    [VerifiesRule("CP-13")]
+    public void ClusterFinalization_ReleasesEveryActiveChunkWriter()
+    {
+        using var dbe = SetupEngineWithGrid();
+        var mmf = ServiceProvider.GetRequiredService<ManagedPagedMMF>();
+
+        Assert.That(mmf.CountPagesWithActiveChunkWriters(), Is.Zero, "precondition: no writer registered before the test spawns anything");
+
+        // Fill one cell, then move every entity out of it. The source cluster empties, which is what queues a
+        // finalisation — the path that leaked. Several entities so more than one page is involved.
+        var ids = new EntityId[24];
+        using (var tx = dbe.CreateQuickTransaction())
+        {
+            for (var i = 0; i < ids.Length; i++)
+            {
+                ids[i] = tx.Spawn<ClMigUnit>(
+                    ClMigUnit.Pos.Set(PointAt(50f, 50f, i)),
+                    ClMigUnit.Scratch.Set(ScratchOf(i, i)));
+            }
+            tx.Commit();
+        }
+        dbe.WriteTickFence(1);
+
+        using (var tx = dbe.CreateQuickTransaction())
+        {
+            for (var i = 0; i < ids.Length; i++)
+            {
+                var eref = tx.OpenMut(ids[i]);
+                ref var pos = ref eref.Write(ClMigUnit.Pos);
+                pos.Bounds = new AABB2F { MinX = 650f, MinY = 650f, MaxX = 650f, MaxY = 650f };
+            }
+            tx.Commit();
+        }
+
+        // Migration executes on the next fence; the emptied cluster is drained on a later one, so run several.
+        for (var tick = 2; tick <= 6; tick++)
+        {
+            dbe.WriteTickFence(tick);
+        }
+
+        Assert.That(mmf.CountPagesWithActiveChunkWriters(), Is.Zero,
+            "every ActiveChunkWriters registration taken during migration and cluster finalisation must be released "
+            + "(CP-13). A non-zero count here means the checkpoint coverage gate will skip those pages forever and "
+            + "the WAL will never be reclaimed — see #817.");
+    }
 }

--- a/test/Typhon.Engine.Tests/Storage/ChangeSetDirtyMarkConservationTests.cs
+++ b/test/Typhon.Engine.Tests/Storage/ChangeSetDirtyMarkConservationTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using Typhon.Engine.Internals;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// Conservation of <c>DirtyCounter</c> marks between <see cref="ChangeSet"/> (per-UoW) and the checkpoint
+/// (background, one <c>DecrementDirty</c> per page per cycle).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The contract under test</b>, stated by <c>ChangeSet.ReleaseExcessDirtyMarks</c> itself: for a page with
+/// tracked mark count <c>N</c> it issues exactly <c>N-1</c> decrements, so "the page contributes exactly one
+/// outstanding mark from this UoW. The next checkpoint cycle's single <c>DecrementDirty</c> brings DC back to its
+/// pre-UoW baseline."
+/// </para>
+/// <para>
+/// That balances for ONE UoW per page per checkpoint cycle. It is silent about K of them. These tests pin both
+/// arms, because the difference between them is a page that is permanently unevictable: DC never returns to zero,
+/// the clock-sweep can never reclaim the page, and the cache eventually starves
+/// (<c>PageCacheBackpressureTimeout</c>) after tens of minutes of ordinary running.
+/// </para>
+/// <para>
+/// Deliberately built from <see cref="ChangeSet"/> and <c>PagedMMF</c> directly rather than by driving the demo or
+/// the tick fence: the question is an arithmetic property of the accounting, and a test that has to run a
+/// simulation for minutes to answer it is a detector, not a proof. Everything here is deterministic and has no
+/// timing component.
+/// </para>
+/// </remarks>
+/// <remarks>
+/// <b>QUARANTINED, deliberately red, tracked by #824.</b> These arms assert the CORRECT accounting, which the
+/// engine does not yet implement — the checkpoint acks one mark per page per cycle while K units of work legitimately
+/// retain one each, so DirtyCounter inflates by K-1 every cycle and the page can never be evicted. They are landed
+/// red on purpose: the alternative is that whoever takes #824 starts with a demo that needs thirty minutes to tell
+/// them they are wrong, instead of a 119 ms oracle that tells them immediately.
+/// <para>
+/// Do NOT make these pass by acking the observed DirtyCounter at capture. That turns all four green and breaks
+/// FlipByteInPage_IsDetected, Truncation_IsDetected and CleanShutdownReopenDoesNotRederive — it consumes marks still
+/// owned by in-flight units of work, which is #385's lost write. Both gates have to hold at once; see #824.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+[Category("Quarantine")]
+internal sealed class ChangeSetDirtyMarkConservationTests : TestBase<ChangeSetDirtyMarkConservationTests>
+{
+    /// <summary>
+    /// Drives ONE real checkpoint cycle and waits for it. Deliberately the real cycle rather than a hand-simulated
+    /// "decrement once" — the ack arithmetic IS the thing under test, so a test that models it can only ever agree
+    /// with whatever the model says.
+    /// </summary>
+    private static void RunCheckpoint(DatabaseEngine dbe)
+    {
+        var cm = dbe.CheckpointManager;
+        Assert.That(cm, Is.Not.Null, "these tests require the checkpoint manager");
+        cm.ForceCheckpoint();
+        Assert.That(cm.WaitForCheckpoint(TimeSpan.FromSeconds(5)), Is.True, "checkpoint cycle did not complete");
+    }
+
+    /// <summary>
+    /// A real, resident data page. Synthetic indices index the live page-state array out of range and tear the host
+    /// down instead of testing anything — the neighbouring guard fixture learned that the hard way.
+    /// </summary>
+    private static int ResidentDataPage(DatabaseEngine dbe)
+    {
+        var (_, _, firstDirty) = dbe.MMF.CountDirtyPages();
+        Assert.That(firstDirty, Is.GreaterThanOrEqualTo(0), "engine init should leave at least one resident dirty page to work with");
+        return firstDirty;
+    }
+
+    /// <summary>
+    /// One UoW: the documented contract holds exactly. Mark, release, one checkpoint ack — back to baseline.
+    /// </summary>
+    /// <remarks>
+    /// This arm exists so the K&gt;1 failure below cannot be dismissed as the harness mismodelling the protocol.
+    /// If this one is red, the test is wrong, not the engine.
+    /// </remarks>
+    [Test]
+    public void SingleUow_ReturnsDirtyCounterToBaseline()
+    {
+        var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        var page = ResidentDataPage(dbe);
+        var baseline = dbe.MMF.DirtyCounterOf(page);
+
+        var cs = new ChangeSet(dbe.MMF);
+        cs.AddByMemPageIndex(page);
+        cs.RegisterReDirty(page);           // a re-dirty within the same UoW — the case N-1 exists to drain
+        cs.ReleaseExcessDirtyMarks();
+
+        Assert.That(dbe.MMF.DirtyCounterOf(page), Is.EqualTo(baseline + 1),
+            "after release a UoW must leave exactly one outstanding mark, whatever it did internally");
+
+        RunCheckpoint(dbe);
+
+        Assert.That(dbe.MMF.DirtyCounterOf(page), Is.Zero,
+            "one checkpoint cycle must return DC to zero, leaving the page evictable");
+    }
+
+    /// <summary>
+    /// K UoWs touching the SAME page inside ONE checkpoint cycle. Each leaves one mark; the cycle acks once.
+    /// DC must still return to baseline — a checkpoint interval is wall-clock (30 s by default) and says nothing
+    /// about how many transactions touched a page inside it.
+    /// </summary>
+    /// <remarks>
+    /// Occupancy/bitmap pages make K large by construction: every transaction that grows a segment marks them, so
+    /// they are the first to become permanently unevictable. Measured in the SpaceBattle demo, a page reached 26
+    /// outstanding marks, and the dirty-page count climbed monotonically to cache exhaustion in ~30 minutes.
+    /// Raising checkpoint frequency reduced the residue 22x (868 dirty pages at 1 cycle, 39 at 1001) — the
+    /// signature of a per-cycle imbalance rather than an absolute leak.
+    /// </remarks>
+    [Test]
+    public void MultipleUowsInOneCheckpointCycle_ReturnDirtyCounterToBaseline([Values(2, 8, 26)] int k)
+    {
+        var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        var page = ResidentDataPage(dbe);
+        var baseline = dbe.MMF.DirtyCounterOf(page);
+
+        for (var i = 0; i < k; i++)
+        {
+            var cs = new ChangeSet(dbe.MMF);
+            cs.AddByMemPageIndex(page);
+            cs.ReleaseExcessDirtyMarks();
+        }
+
+        Assert.That(dbe.MMF.DirtyCounterOf(page), Is.EqualTo(baseline + k),
+            "each unit of work legitimately retains one mark until a checkpoint captures its changes");
+
+        RunCheckpoint(dbe);                 // ONE cycle — it captured all K, so it must ack all K
+
+        Assert.That(dbe.MMF.DirtyCounterOf(page), Is.Zero,
+            $"{k} UoWs touched one page inside a single checkpoint cycle; each left one mark and the cycle acked "
+            + "once, so DC is left permanently inflated. The page can never be evicted (PS-01), and the page cache "
+            + "starves once enough pages reach this state.");
+    }
+}


### PR DESCRIPTION
Fixes #817. Found while hardening with the SpaceBattle demo.

## The bug

`ArchetypeClusterState.DrainPendingClusterFinalizations` opened two `ChunkAccessor`s, read each drained chunk via `GetChunkAddress(chunkId, dirty: true)`, and returned without disposing either. That `dirty` flag registers an `ActiveChunkWriter` on the chunk's page, and the registration is released **only** by `CommitChanges`/`Dispose` — so every drained cluster left one behind permanently.

The consequence lands three layers away, in a subsystem that never mentions clusters:

```
migration leaks ACW → page permanently ACW≠0 → CP-11 skips it → CK-03 gates every cycle
                    → CheckpointLSN never advances → CK-04 recycles no WAL segment
                    → log grows at the full write rate → writer stalls → WalBackPressureTimeout
```

22 GB of WAL across 86 segments in four minutes, against a 120 MB data file.

## Evidence

Measured with the workload **quiescent** — tick loop stopped, no transaction open:

```
skipped 458   repeated-from-previous-cycle 450   longest single-page streak 40
causes: ACW 24738   writer-held>100ms 0   stale-counter 0
QUIESCENT non-zero ACW: 458 of 458    139:acw=1  140:acw=2  163:acw=4  186:acw=11
```

Every skipped page still held registrations with nothing running; one held eleven. Isolated to migration by A/B (identical config, one giant cell ⇒ zero migrations):

| | migrations/tick | quiescent ACW ≠ 0 | gated cycles |
|---|---|---|---|
| `cellSize=2000` | 24 | 45 of 45 | 12 |
| `cellSize=200000` | **0** | **0 of 0** | **0** |

## The fix and its effect

Two `using`s. Same workload, 40 checkpoints, 51 migrations/tick:

| | before | after |
|---|---|---|
| Segments recycled | 0 | **11** |
| Consecutive gated cycles | 40 | **0** |
| Pages skipped | 458 | **0** |
| Quiescent non-zero ACW | 458 of 458 | **0 of 0** |
| WAL after 2000 ticks | 22 GB / 86 files | **2.3 GB / 9 files** |

## CP-13 — the invariant that was missing, not just untested

CP-11 constrains *when* ACW may be observed non-zero; CP-12 *when* the decrement may be deferred. **Neither required that it ever happen.** That is why a leaked registration was legal and why 5 000+ tests walked past it.

`ClusterFinalization_ReleasesEveryActiveChunkWriter` verifies it — empties a cluster, then asserts no page holds a registration once nothing is in flight. **Red without the fix** (`Expected: 0, But was: 1`). Quiescence is the whole trick: while a workload runs, a leaked counter is indistinguishable from a busy one.

## Also included: a quarantined oracle for #824

`ChangeSetDirtyMarkConservationTests` lands **deliberately red** under `[Category("Quarantine")]`, tracking #824 — a second, unrelated counter defect found in the same session. `DirtyCounter` inflates by K−1 per checkpoint cycle when K units of work touch one page, so pages become permanently unevictable and the cache eventually starves with `PageCacheBackpressureTimeout`.

It proves that in **119 ms** where the demo needs half an hour, and its remarks record the fix that looks right and is not: acking the observed `DirtyCounter` at capture turns all four arms green and breaks `FlipByteInPage_IsDetected`, `Truncation_IsDetected` and `CleanShutdownReopenDoesNotRederive` — it consumes marks still owned by in-flight units of work, which is #385's lost write. Whoever takes #824 starts with a gate that rejects the naive fix instead of a demo that takes thirty minutes to say so.

The four page-counter census helpers on `PagedMMF` exist for these assertions and are read only at quiesce.

## Verification

- Full suite `--filter "TestCategory!=Quarantine"`: **5460 passed, 0 failed, 16 skipped**
- `ClusterMigrationTests`: 25/25
- CP-13 test confirmed red without the fix, green with it
- `scripts/pre-push.sh --policy`: passed
- Quarantine filter confirmed to exclude the #824 oracle from the gate

Not included: the demo itself (`demo/SpaceBattle`) and the investigation scaffolding used to find this — ACW/DC stack-trace ledgers, skip-cause counters, skip-identity diagnostics. They did their job and shouldn't outlive it; the reproduction is recorded in #817 and #824.
