### PR TITLE
Rate test asserted against the sleep it requested, not the interval the engine measured

### DIFF
--- a/test/Typhon.Engine.Tests/Resources/ResourceSnapshotTests.cs
+++ b/test/Typhon.Engine.Tests/Resources/ResourceSnapshotTests.cs
@@ -208,30 +208,52 @@ public class ResourceSnapshotTests
         Assert.That(snapshot.Rates.ContainsNode("Root/Storage/PageCache"), Is.True);
     }
 
+    /// <remarks>
+    /// The oracle reads the interval the engine itself measured (<see cref="ResourceSnapshot.Timestamp"/> on both
+    /// snapshots) rather than assuming <see cref="Thread.Sleep(int)"/> honours its argument. Asserting a rate band
+    /// derived from the requested 100ms is what reddened the arm64 nightly twice: a hosted macOS VM overslept 2.5x,
+    /// so 100 ops landed in a 250ms window and the "approximately 1000 ops/sec" came out at 400. The sleep below
+    /// only has to make the interval non-zero - its accuracy is deliberately not part of the assertion.
+    /// </remarks>
     [Test]
     public void GetSnapshot_RatesComputedCorrectly()
     {
+        // Non-zero starting counts so that delta != absolute count: starting both at 0 would make a
+        // "rate = count / elapsed" regression indistinguishable from the correct "rate = delta / elapsed".
         var resource = new TestMetricResource("PageCache", _registry.Storage)
         {
-            CacheHits = 0,
-            CacheMisses = 0
+            CacheHits = 1000,
+            CacheMisses = 400
         };
         _registry.Storage.RegisterChild(resource);
 
-        // First snapshot
-        _graph.GetSnapshot();
+        var first = _graph.GetSnapshot();
 
-        // Wait 100ms and add 100 hits
-        Thread.Sleep(100);
-        resource.CacheHits = 100;
+        // DateTime.UtcNow advances in ~15.6ms steps on Windows, so sleep a few ticks' worth to guarantee the
+        // interval is non-zero - ComputeRates returns null for elapsed <= 0.
+        Thread.Sleep(50);
+        resource.CacheHits = 1100;   // delta 100
+        resource.CacheMisses = 450;  // delta 50
 
-        // Second snapshot
-        var snapshot = _graph.GetSnapshot();
+        var second = _graph.GetSnapshot();
 
-        // Should be approximately 1000 ops/sec (100 ops in 0.1 sec)
-        var rate = snapshot.Rates.GetRate("Root/Storage/PageCache", "CacheHits");
-        Assert.That(rate, Is.GreaterThan(500), "Rate should be > 500 ops/sec");
-        Assert.That(rate, Is.LessThan(2000), "Rate should be < 2000 ops/sec");
+        var elapsedSeconds = (second.Timestamp - first.Timestamp).TotalSeconds;
+        Assert.That(elapsedSeconds, Is.GreaterThan(0), "Snapshot timestamps must advance for rates to exist");
+
+        var hitRate = second.Rates.GetRate("Root/Storage/PageCache", "CacheHits");
+        var missRate = second.Rates.GetRate("Root/Storage/PageCache", "CacheMisses");
+
+        Assert.Multiple(() =>
+        {
+            // Rate is the counter DELTA over the measured window, in ops/sec - not the absolute count, and not
+            // ops/ms. Both are pinned against the window the engine reported.
+            Assert.That(hitRate, Is.EqualTo(100 / elapsedSeconds).Within(1e-6).Percent, "CacheHits rate is delta/elapsed");
+            Assert.That(missRate, Is.EqualTo(50 / elapsedSeconds).Within(1e-6).Percent, "CacheMisses rate is delta/elapsed");
+
+            // Clock-independent cross-check: both metrics span the SAME window, so their rates must hold the same
+            // ratio as their deltas whatever the wall-clock did. No amount of scheduler jitter can perturb this.
+            Assert.That(hitRate, Is.EqualTo(missRate * 2).Within(1e-6).Percent, "100 hits vs 50 misses over one window");
+        });
     }
 
     [Test]


### PR DESCRIPTION
The arm64 (macOS) nightly has gone red twice on a single test — [run 31917629628](https://github.com/Log2n-io/Typhon/actions/runs/31917629628) (08-16) and [run 32433359797](https://github.com/Log2n-io/Typhon/actions/runs/32433359797) (08-21):

```
x Typhon.Engine.Tests.ResourceSnapshotTests.GetSnapshot_RatesComputedCorrectly
  Assert.That(rate, Is.GreaterThan(500))
  But was: 399.65
```

## What was wrong

The test slept 100ms, added 100 hits, and asserted the resulting rate landed in `(500, 2000)` — a band around the "approximately 1000 ops/sec" that 100 ops in 0.1s implies. That is an assertion about `Thread.Sleep`, not about the engine. On a hosted macOS VM the sleep overran 2.5x, putting 100 ops in a ~250ms window: 400 ops/sec, and a 2x margin on the lower bound cannot absorb that.

Not a regression, and not an engine bug:

- The same commit `be696c4c` passed the previous nightly ([32317827885](https://github.com/Log2n-io/Typhon/actions/runs/32317827885)); the 08-16 failure was on a different commit.
- `ResourceGraph.ComputeRates` divides the counter delta by `currentTimestamp - previous.Timestamp`, exactly as `claude/design/Resources/06-snapshot-api.md:443-477` specifies. Unchanged here.

Worth noting for the next time this shape appears: oversleep is persistent for the duration of a job, not per-test, so `shard.py`'s retry-alone pass — which exists to separate contention flakes from real regressions — classified it as BLOCKING through both retries.

## The fix

The oracle now reads the interval the engine itself measured, off the two snapshots' public `Timestamp` values — the same two values `ComputeRates` uses. It still pins the formula (delta rather than absolute count, per second rather than per millisecond, keyed to the right node and metric) without depending on the sleep being honoured. The sleep survives only to guarantee the interval is non-zero: `ComputeRates` returns null for `elapsed <= 0`, and `DateTime.UtcNow` advances in ~15.6ms steps on Windows.

A second metric carrying half the delta adds a cross-check that no scheduler jitter can perturb — both metrics span the same window, so their rates must hold a 2:1 ratio whatever the wall clock did.

The starting counters moved off zero deliberately. A counter starting at 0 has delta equal to its absolute count, which leaves a `rate = count / elapsed` regression indistinguishable from the correct one; the first draft of this assertion had exactly that hole.

## Verification

A rewritten assertion is worth nothing if it cannot fail, so:

| Check | Result |
|---|---|
| Mutant: `delta / elapsed` → `metric.Count / elapsed` | killed |
| Mutant: `.TotalSeconds` → `.TotalMilliseconds` | killed |
| Sleep stretched 50 → 400ms (8x, worse than the observed 2.5x) | passes; the old assertion would read 250 ops/sec and go red |
| `ResourceSnapshotTests`, 3 runs | 27/27 each |
| Full suite, `--filter "TestCategory!=Quarantine"` | **5536 passed, 0 failed, 16 skipped** |
| `scripts/pre-push.sh --policy` | passed |

Two earlier full-suite runs each lost one *Storage* test (`SeqlockCounterSlotReuseTests`), which passes 3/3 in isolation — the #720 parallel-fixture flake band, unrelated to this change.

## Not included

`ThroughputRates_IndexerReturnsEmptyForUnknownPath` and `ThroughputRates_GetRateReturnsZeroForUnknown` sleep 10ms and then dereference `snapshot.Rates` unconditionally; if `UtcNow` fails to advance across that window they NRE instead of failing legibly. Same family, but neither has ever gone red, so hardening them here would be speculative.
